### PR TITLE
add `cygwin` to list of $TERM variables

### DIFF
--- a/has-color.js
+++ b/has-color.js
@@ -20,5 +20,5 @@ module.exports = (function () {
 		return true;
 	}
 
-	return /^screen|^xterm|color|ansi|linux/i.test(process.env.TERM);
+	return /^screen|^xterm|color|ansi|cygwin|linux/i.test(process.env.TERM);
 })();


### PR DESCRIPTION
This detects color support for cygwin terminals.
