### PR TITLE
Update has-color.js

### DIFF
--- a/has-color.js
+++ b/has-color.js
@@ -8,7 +8,7 @@ module.exports = (function () {
 		return true;
 	}
 
-	if (!process.stdout.isTTY) {
+	if (process.stdout && !process.stdout.isTTY) {
 		return false;
 	}
 


### PR DESCRIPTION
protect isTTY call when process.stdout == undefined

By doing so, you prevent `Uncaught TypeError: Cannot read property 'isTTY' of undefined` from being thrown while using `chalk` with **browserify** :)
