### PR TITLE
Support --colors and --no-colors flags used by Mocha

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,11 +3,13 @@ var argv = process.argv;
 
 module.exports = (function () {
 	if (argv.indexOf('--no-color') !== -1 ||
+		argv.indexOf('--no-colors') !== -1 ||
 		argv.indexOf('--color=false') !== -1) {
 		return false;
 	}
 
 	if (argv.indexOf('--color') !== -1 ||
+		argv.indexOf('--colors') !== -1 ||
 		argv.indexOf('--color=true') !== -1 ||
 		argv.indexOf('--color=always') !== -1) {
 		return true;

--- a/test.js
+++ b/test.js
@@ -18,8 +18,18 @@ it('should return false if --no-color flag is used', function () {
 	assert.equal(requireUncached('./'), false);
 });
 
+it('should return false if --no-colors flag is used', function () {
+	process.argv = ['--no-colors'];
+	assert.equal(requireUncached('./'), false);
+});
+
 it('should return true if --color flag is used', function () {
 	process.argv = ['--color'];
+	assert.equal(requireUncached('./'), true);
+});
+
+it('should return true if --colors flag is used', function () {
+	process.argv = ['--colors'];
 	assert.equal(requireUncached('./'), true);
 });
 


### PR DESCRIPTION
Hi @sindresorhus, this pull request adds support for the command line flags `--colors` and `--no-colors` that is used by Mocha.

If you are interested I can elaborate more on why I would like this change to get merged.
