### PR TITLE
added 256/16m color support and results

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -11,6 +11,13 @@ $ npm install --save supports-color
 
 
 ## Usage
+supports-color exports an object with color information, or `null` if color is not supported.
+
+The returned object specifies a level of support for color through a `.level` property and a corresponding flag:
+
+- `.level = 1` and `.hasBasic = true`: Basic color support (16 colors)
+- `.level = 2` and `.has256 = true`: 256 color support
+- `.level = 3` and `.has16m = true`: 16 million (truecolor) support
 
 ```js
 var supportsColor = require('supports-color');
@@ -18,12 +25,21 @@ var supportsColor = require('supports-color');
 if (supportsColor) {
 	console.log('Terminal supports color');
 }
+
+if (supportsColor.has256) {
+	console.log('Terminal supports 256 colors');
+}
+
+if (supportsColor.has16m) {
+	console.log('Terminal supports 16 million colors (truecolor)');
+}
 ```
 
 It obeys the `--color` and `--no-color` CLI flags.
 
 For situations where using `--color` is not possible, add an environment variable `FORCE_COLOR` with any value to force color. Trumps `--no-color`.
 
+Explicit 256/truecolor mode can be enabled using the `--color=256` and `--color=16m` flags, respectively.
 
 ## Related
 

--- a/test.js
+++ b/test.js
@@ -1,4 +1,7 @@
 'use strict';
+/* global it */
+/* global beforeEach */
+
 var assert = require('assert');
 var requireUncached = require('require-uncached');
 
@@ -10,55 +13,115 @@ beforeEach(function () {
 
 it('should return true if `FORCE_COLOR` is in env', function () {
 	process.env.FORCE_COLOR = true;
-	assert.equal(requireUncached('./'), true);
+	var result = requireUncached('./');
+	assert.equal(!!result, true);
+	assert.equal(result.level, 1);
 });
 
 it('should return false if not TTY', function () {
 	process.stdout.isTTY = false;
-	assert.equal(requireUncached('./'), false);
+	var result = requireUncached('./');
+	assert.equal(!!result, false);
 });
 
 it('should return false if --no-color flag is used', function () {
 	process.argv = ['--no-color'];
-	assert.equal(requireUncached('./'), false);
+	var result = requireUncached('./');
+	assert.equal(!!result, false);
 });
 
 it('should return false if --no-colors flag is used', function () {
 	process.argv = ['--no-colors'];
-	assert.equal(requireUncached('./'), false);
+	var result = requireUncached('./');
+	assert.equal(!!result, false);
 });
 
 it('should return true if --color flag is used', function () {
 	process.argv = ['--color'];
-	assert.equal(requireUncached('./'), true);
+	var result = requireUncached('./');
+	assert.equal(!!result, true);
 });
 
 it('should return true if --colors flag is used', function () {
 	process.argv = ['--colors'];
-	assert.equal(requireUncached('./'), true);
+	var result = requireUncached('./');
+	assert.equal(!!result, true);
 });
 
 it('should return true if `COLORTERM` is in env', function () {
 	process.env.COLORTERM = true;
-	assert.equal(requireUncached('./'), true);
+	var result = requireUncached('./');
+	assert.equal(!!result, true);
 });
 
 it('should support `--color=true` flag', function () {
 	process.argv = ['--color=true'];
-	assert.equal(requireUncached('./'), true);
+	var result = requireUncached('./');
+	assert.equal(!!result, true);
 });
 
 it('should support `--color=always` flag', function () {
 	process.argv = ['--color=always'];
-	assert.equal(requireUncached('./'), true);
+	var result = requireUncached('./');
+	assert.equal(!!result, true);
 });
 
 it('should support `--color=false` flag', function () {
 	process.argv = ['--color=false'];
-	assert.equal(requireUncached('./'), false);
+	var result = requireUncached('./');
+	assert.equal(!!result, false);
+});
+
+it('should support `--color=256` flag', function () {
+	process.argv = ['--color=256'];
+	var result = requireUncached('./');
+	assert.equal(!!result, true);
+});
+
+it('level should be 2 if `--color=256` flag is used', function () {
+	process.argv = ['--color=256'];
+	var result = requireUncached('./');
+	assert.equal(result.level, 2);
+	assert.equal(result.has256, true);
+});
+
+it('should support `--color=16m` flag', function () {
+	process.argv = ['--color=256'];
+	var result = requireUncached('./');
+	assert.equal(!!result, true);
+});
+
+it('should support `--color=full` flag', function () {
+	process.argv = ['--color=full'];
+	var result = requireUncached('./');
+	assert.equal(!!result, true);
+});
+
+it('should support `--color=truecolor` flag', function () {
+	process.argv = ['--color=truecolor'];
+	var result = requireUncached('./');
+	assert.equal(!!result, true);
+});
+
+it('level should be 2 if `--color=16m` flag is used', function () {
+	process.argv = ['--color=16m'];
+	var result = requireUncached('./');
+	assert.equal(result.level, 3);
+	assert.equal(result.has256, true);
+	assert.equal(result.has16m, true);
 });
 
 it('should ignore post-terminator flags', function () {
 	process.argv = ['--color', '--', '--no-color'];
-	assert.equal(requireUncached('./'), true);
+	var result = requireUncached('./');
+	assert.equal(!!result, true);
+});
+
+it('should allow tests of the properties on false', function() {
+	process.argv = ['--no-color'];
+	var result = requireUncached('./');
+	assert.equal(!!(result.hasBasic), false);
+	assert.equal(!!(result.has256), false);
+	assert.equal(!!(result.has16m), false);
+	assert.equal(result.level > 0, false);
 });


### PR DESCRIPTION
So we're to the point in technology where we shouldn't be bound to the standard 16 colors of the terminal.

We now support `TERM=xterm-256color` and *should* be moving toward [truecolor (16 million) color support](http://stackoverflow.com/questions/15682537/ansi-color-specific-rgb-sequence-bash/26665998#26665998). Although there isn't a standard `TERM` setting for it, we should still support it on the command line.

This *does*, however, break code that does either a `== true` or `=== true` (or `false`) check. Ternary operators and type coercion should be unaffected (as is the *cli.js*).

I understand this may be unacceptable, but us more aesthetic individuals are pining for more 256 (or even 16m) support in our programs. Most modern day terminals support 256 color, and a large number of terminals [now support 16 million (truecolor) ANSI render modes](https://gist.github.com/XVilka/8346728#now-supporting-truecolor).

If this PR doesn't get accepted, I plan on forking this into a new module, `supports-color-256`.