### PR TITLE
Disable colored console output in Electron

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,6 +37,10 @@ var supportLevel = (function () {
 		hasFlag('color=always')) {
 		return 1;
 	}
+	
+	if (process.versions['electron']) {
+		return 0;
+	}
 
 	if (process.stdout && !process.stdout.isTTY) {
 		return 0;

--- a/index.js
+++ b/index.js
@@ -38,7 +38,7 @@ var supportLevel = (function () {
 		return 1;
 	}
 	
-	if (process.versions['electron']) {
+	if ('electron' in process.versions) {
 		return 0;
 	}
 


### PR DESCRIPTION
Work around https://github.com/atom/electron/issues/1647, since Electron doesn't support color output anyways - since many libraries use Chalk internally it's not as easy to disable. 