### PR TITLE
Add ability to force disable colors with an environment variable

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ var supportLevel = (function () {
 
 if ('FORCE_COLOR' in process.env) {
 	var forceColor = parseInt(process.env.FORCE_COLOR, 10);
-	supportLevel = forceColor === 0 ? 0 : supportLevel || 1;
+	supportLevel = forceColor === 0 ? 0 : (supportLevel || 1);
 }
 
 module.exports = process && support(supportLevel);

--- a/index.js
+++ b/index.js
@@ -77,8 +77,9 @@ var supportLevel = (function () {
 	return 0;
 })();
 
-if (supportLevel === 0 && 'FORCE_COLOR' in process.env) {
-	supportLevel = 1;
+if ('FORCE_COLOR' in process.env) {
+	var forceColor = parseInt(process.env.FORCE_COLOR, 10);
+	supportLevel = forceColor === 0 ? 0 : supportLevel || 1;
 }
 
 module.exports = process && support(supportLevel);

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ The returned object specifies a level of support for color through a `.level` pr
 
 It obeys the `--color` and `--no-color` CLI flags.
 
-For situations where using `--color` is not possible, add an environment variable `FORCE_COLOR` with any value to force color. If `FORCE_COLOR` is set to `0`, colors are force disabled. Trumps `--no-color` / color flags, respectively.
+For situations where using `--color` is not possible, add an environment variable `FORCE_COLOR=1` to forcefully enable color. Alternatively, `FORCE_COLOR=0` will be forcefully disabled. The use of `FORCE_COLOR` negates all other color checks performed by this module.
 
 Explicit 256/truecolor mode can be enabled using the `--color=256` and `--color=16m` flags, respectively.
 

--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ The returned object specifies a level of support for color through a `.level` pr
 
 It obeys the `--color` and `--no-color` CLI flags.
 
-For situations where using `--color` is not possible, add an environment variable `FORCE_COLOR` with any value to force color. Trumps `--no-color`.
+For situations where using `--color` is not possible, add an environment variable `FORCE_COLOR` with any value to force color. If `FORCE_COLOR` is set to `0`, colors are force disabled. Trumps `--no-color` / color flags, respectively.
 
 Explicit 256/truecolor mode can be enabled using the `--color=256` and `--color=16m` flags, respectively.
 

--- a/test.js
+++ b/test.js
@@ -15,6 +15,20 @@ it('should return true if `FORCE_COLOR` is in env', function () {
 	assert.equal(result.level, 1);
 });
 
+it('should return true if `FORCE_COLOR` is in env, but honor 256', function () {
+	process.argv = ['--color=256'];
+	process.env.FORCE_COLOR = true;
+	var result = requireUncached('./');
+	assert.equal(Boolean(result), true);
+	assert.equal(result.level, 2);
+});
+
+it('should return false if `FORCE_COLOR` is in env and is 0', function () {
+	process.env.FORCE_COLOR = '0';
+	var result = requireUncached('./');
+	assert.equal(Boolean(result), false);
+});
+
 it('should return false if not TTY', function () {
 	process.stdout.isTTY = false;
 	var result = requireUncached('./');

--- a/test.js
+++ b/test.js
@@ -23,6 +23,14 @@ it('should return true if `FORCE_COLOR` is in env, but honor 256', function () {
 	assert.equal(result.level, 2);
 });
 
+it('should return true if `FORCE_COLOR` is in env, but honor 256', function () {
+	process.argv = ['--color=256'];
+	process.env.FORCE_COLOR = '1';
+	var result = requireUncached('./');
+	assert.equal(Boolean(result), true);
+	assert.equal(result.level, 2);
+});
+
 it('should return false if `FORCE_COLOR` is in env and is 0', function () {
 	process.env.FORCE_COLOR = '0';
 	var result = requireUncached('./');


### PR DESCRIPTION
So this extends the `FORCE_COLOR` environment variable to allow `FORCE_COLOR=0` (preserving the behavior of just `FORCE_COLOR=`), which will forcibly _disable_ color environment-wide.

This was inspired by the bug over at atom/electron#1647
