### PR TITLE
Check for CLICOLOR and CLICOLOR_FORCE. Fixes #31 and #32.

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,6 +38,14 @@ var supportLevel = (function () {
 		return 1;
 	}
 
+	if (process.env.CLICOLOR === '0') {
+		return 0;
+	}
+
+	if ('CLICOLOR' in process.env && process.stdout && process.stdout.isTTY) {
+		return 1;
+	}
+
 	if (process.stdout && !process.stdout.isTTY) {
 		return 0;
 	}
@@ -65,7 +73,8 @@ var supportLevel = (function () {
 	return 0;
 })();
 
-if (supportLevel === 0 && 'FORCE_COLOR' in process.env) {
+if (supportLevel === 0 && ('FORCE_COLOR' in process.env ||
+    ('CLICOLOR_FORCE' in process.env && process.env.CLICOLOR_FORCE !== '0'))) {
 	supportLevel = 1;
 }
 

--- a/test.js
+++ b/test.js
@@ -15,6 +15,27 @@ it('should return true if `FORCE_COLOR` is in env', function () {
 	assert.equal(result.level, 1);
 });
 
+it('should return true if `CLICOLOR_FORCE` is != 0', function () {
+	process.env.CLICOLOR_FORCE = '1';
+	process.stdout.isTTY = false;
+	var result = requireUncached('./');
+	assert.equal(Boolean(result), true);
+	assert.equal(result.level, 1);
+});
+
+it('should return false if `CLICOLOR` is 0', function () {
+	process.env.CLICOLOR = '0';
+	var result = requireUncached('./');
+	assert.equal(Boolean(result), false);
+});
+
+it('should return true if `CLICOLOR` is != 0', function () {
+	process.env.CLICOLOR = '1';
+	var result = requireUncached('./');
+	assert.equal(Boolean(result), true);
+	assert.equal(result.level, 1);
+});
+
 it('should return false if not TTY', function () {
 	process.stdout.isTTY = false;
 	var result = requireUncached('./');


### PR DESCRIPTION
I wasn't sure about prioritizing the different ways to enable color. I thought that command line flags should come first. Furthermore `FORCE_COLOR` still trumps `CLICOLOR=0`.

CLICOLOR(_FORCE) only enables 16 colors for now.
