### PR TITLE
modify stdout stream check

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,7 +38,8 @@ var supportLevel = (function () {
 		return 1;
 	}
 
-	if (process.stdout && !process.stdout.isTTY) {
+	if ((process.stdout && !process.stdout.isTTY) &&
+		(process.stderr && !process.stderr.isTTY)) {
 		return 0;
 	}
 


### PR DESCRIPTION
In [autocannon](https://github.com/mcollina/autocannon), we do progress & result logging on stderr, but we do json result logging on stdout.

This allows users to pipe the results logged on stdout to a file, but still see the progress bar on stderr. In the case we send stdout to a file, stdout is not a tty, but we still want to support color with stderr as a tty.

This modifies the stdout.isTTY to check if stderr is a TTY too. If both aren't TTY's, then this should return 0.

Relevant issue in autocannon: https://github.com/mcollina/autocannon/issues/59