### PR TITLE
Allow users to specify stream to test

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 var hasFlag = require('has-flag');
+var stdoutSupport = require('./stdout')
 
 var support = function (level) {
 	if (level === 0) {
@@ -14,7 +15,8 @@ var support = function (level) {
 	};
 };
 
-var supportLevel = (function () {
+var supportLevel = (function (stream) {
+	stream = stream || process.stdout
 	if (hasFlag('no-color') ||
 		hasFlag('no-colors') ||
 		hasFlag('color=false')) {
@@ -38,7 +40,7 @@ var supportLevel = (function () {
 		return 1;
 	}
 
-	if (process.stdout && !process.stdout.isTTY) {
+	if (stream && !stream.isTTY) {
 		return 0;
 	}
 
@@ -67,10 +69,10 @@ var supportLevel = (function () {
 	}
 
 	return 0;
-})();
+})(stream);
 
 if (supportLevel === 0 && 'FORCE_COLOR' in process.env) {
 	supportLevel = 1;
 }
 
-module.exports = process && support(supportLevel);
+module.exports = (function (stream) { return process && support(supportLevel(stream)); })(stream)

--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 var hasFlag = require('has-flag');
-var stdoutSupport = require('./stdout')
 
 var support = function (level) {
 	if (level === 0) {
@@ -15,8 +14,7 @@ var support = function (level) {
 	};
 };
 
-var supportLevel = (function (stream) {
-	stream = stream || process.stdout
+var checkStreamSupportLevel = function (stream) {
 	if (hasFlag('no-color') ||
 		hasFlag('no-colors') ||
 		hasFlag('color=false')) {
@@ -69,10 +67,17 @@ var supportLevel = (function (stream) {
 	}
 
 	return 0;
-})(stream);
+};
 
-if (supportLevel === 0 && 'FORCE_COLOR' in process.env) {
-	supportLevel = 1;
-}
+var checkSupport = function (stream) {
+	stream = stream || process.stdout;
+	var supportLevelForStream = checkStreamSupportLevel(stream);
 
-module.exports = (function (stream) { return process && support(supportLevel(stream)); })(stream)
+	if (supportLevelForStream === 0 && 'FORCE_COLOR' in process.env) {
+		supportLevelForStream = 1;
+	}
+
+	return process && support(supportLevelForStream);
+};
+
+module.exports = checkSupport;

--- a/readme.md
+++ b/readme.md
@@ -13,23 +13,28 @@ $ npm install --save supports-color
 ## Usage
 
 ```js
-var supportsColor = require('supports-color');
+var supportsColor = require('supports-color')
+var stdoutColorSupport = supportsColor(process.stdout);
 
-if (supportsColor) {
+if (stdoutColorSupport) {
 	console.log('Terminal supports color');
 }
 
-if (supportsColor.has256) {
+if (stdoutColorSupport.has256) {
 	console.log('Terminal supports 256 colors');
 }
 
-if (supportsColor.has16m) {
+if (stdoutColorSupport.has16m) {
 	console.log('Terminal supports 16 million colors (truecolor)');
 }
 ```
 
 
 ## API
+
+```supportsColor(stream)```
+
+- `stream` is the stream to check for color support. Checks stdout by default if none supplied.
 
 Returns an `object`, or `false` if color is not supported.
 

--- a/test.js
+++ b/test.js
@@ -4,108 +4,126 @@ var requireUncached = require('require-uncached');
 
 beforeEach(function () {
 	process.stdout.isTTY = true;
+	process.stderr.isTTY = true;
 	process.argv = [];
 	process.env = {};
 });
 
 it('should return true if `FORCE_COLOR` is in env', function () {
 	process.env.FORCE_COLOR = true;
-	var result = requireUncached('./');
+	var result = requireUncached('./')();
 	assert.equal(Boolean(result), true);
 	assert.equal(result.level, 1);
 });
 
-it('should return false if not TTY', function () {
+it('should return false if stdout not TTY', function () {
 	process.stdout.isTTY = false;
-	var result = requireUncached('./');
+	var result = requireUncached('./')();
 	assert.equal(Boolean(result), false);
+});
+
+it('should test stdout by default', function () {
+	process.env = {TERM: 'xterm-256color'};
+	process.stdout.isTTY = false;
+	var supportsColor = requireUncached('./');
+	var defaultResult = supportsColor();
+	var stdoutResult = supportsColor(process.stdout);
+	assert.equal(defaultResult, stdoutResult);
+
+	process.stdout.isTTY = true;
+	defaultResult = supportsColor();
+	stdoutResult = supportsColor(process.stdout);
+	assert.equal(defaultResult.level, stdoutResult.level);
+	assert.equal(defaultResult.hasBasic, stdoutResult.hasBasic);
+	assert.equal(defaultResult.has256, stdoutResult.has256);
+	assert.equal(defaultResult.has16m, stdoutResult.has16m);
 });
 
 it('should return false if --no-color flag is used', function () {
 	process.env = {TERM: 'xterm-256color'};
 	process.argv = ['--no-color'];
-	var result = requireUncached('./');
+	var result = requireUncached('./')();
 	assert.equal(Boolean(result), false);
 });
 
 it('should return false if --no-colors flag is used', function () {
 	process.env = {TERM: 'xterm-256color'};
 	process.argv = ['--no-colors'];
-	var result = requireUncached('./');
+	var result = requireUncached('./')();
 	assert.equal(Boolean(result), false);
 });
 
 it('should return true if --color flag is used', function () {
 	process.argv = ['--color'];
-	var result = requireUncached('./');
+	var result = requireUncached('./')();
 	assert.equal(Boolean(result), true);
 });
 
 it('should return true if --colors flag is used', function () {
 	process.argv = ['--colors'];
-	var result = requireUncached('./');
+	var result = requireUncached('./')();
 	assert.equal(Boolean(result), true);
 });
 
 it('should return true if `COLORTERM` is in env', function () {
 	process.env.COLORTERM = true;
-	var result = requireUncached('./');
+	var result = requireUncached('./')();
 	assert.equal(Boolean(result), true);
 });
 
 it('should support `--color=true` flag', function () {
 	process.argv = ['--color=true'];
-	var result = requireUncached('./');
+	var result = requireUncached('./')();
 	assert.equal(Boolean(result), true);
 });
 
 it('should support `--color=always` flag', function () {
 	process.argv = ['--color=always'];
-	var result = requireUncached('./');
+	var result = requireUncached('./')();
 	assert.equal(Boolean(result), true);
 });
 
 it('should support `--color=false` flag', function () {
 	process.env = {TERM: 'xterm-256color'};
 	process.argv = ['--color=false'];
-	var result = requireUncached('./');
+	var result = requireUncached('./')();
 	assert.equal(Boolean(result), false);
 });
 
 it('should support `--color=256` flag', function () {
 	process.argv = ['--color=256'];
-	var result = requireUncached('./');
+	var result = requireUncached('./')();
 	assert.equal(Boolean(result), true);
 });
 
 it('level should be 2 if `--color=256` flag is used', function () {
 	process.argv = ['--color=256'];
-	var result = requireUncached('./');
+	var result = requireUncached('./')();
 	assert.equal(result.level, 2);
 	assert.equal(result.has256, true);
 });
 
 it('should support `--color=16m` flag', function () {
 	process.argv = ['--color=16m'];
-	var result = requireUncached('./');
+	var result = requireUncached('./')();
 	assert.equal(Boolean(result), true);
 });
 
 it('should support `--color=full` flag', function () {
 	process.argv = ['--color=full'];
-	var result = requireUncached('./');
+	var result = requireUncached('./')();
 	assert.equal(Boolean(result), true);
 });
 
 it('should support `--color=truecolor` flag', function () {
 	process.argv = ['--color=truecolor'];
-	var result = requireUncached('./');
+	var result = requireUncached('./')();
 	assert.equal(Boolean(result), true);
 });
 
 it('level should be 3 if `--color=16m` flag is used', function () {
 	process.argv = ['--color=16m'];
-	var result = requireUncached('./');
+	var result = requireUncached('./')();
 	assert.equal(result.level, 3);
 	assert.equal(result.has256, true);
 	assert.equal(result.has16m, true);
@@ -113,14 +131,14 @@ it('level should be 3 if `--color=16m` flag is used', function () {
 
 it('should ignore post-terminator flags', function () {
 	process.argv = ['--color', '--', '--no-color'];
-	var result = requireUncached('./');
+	var result = requireUncached('./')();
 	assert.equal(Boolean(result), true);
 });
 
 it('should allow tests of the properties on false', function () {
 	process.env = {TERM: 'xterm-256color'};
 	process.argv = ['--no-color'];
-	var result = requireUncached('./');
+	var result = requireUncached('./')();
 	assert.equal(Boolean(result.hasBasic), false);
 	assert.equal(Boolean(result.has256), false);
 	assert.equal(Boolean(result.has16m), false);
@@ -129,12 +147,35 @@ it('should allow tests of the properties on false', function () {
 
 it('should return false if `CI` is in env', function () {
 	process.env.CI = 'Travis';
-	var result = requireUncached('./');
+	var result = requireUncached('./')();
 	assert.equal(Boolean(result), false);
 });
 
 it('should return false if `TEAMCITY_VERSION` is in env', function () {
 	process.env.TEAMCITY_VERSION = '9.0.5 (build 32523)';
-	var result = requireUncached('./');
+	var result = requireUncached('./')();
 	assert.equal(Boolean(result), false);
+});
+
+it('should return true when checking stderr tty', function () {
+	process.env = {TERM: 'xterm-256color'};
+	var stderrRes = requireUncached('./')(process.stderr);
+	assert.equal(Boolean(stderrRes), true);
+});
+
+it('should return false when stderr is not a tty', function () {
+	process.env = {TERM: 'xterm-256color'};
+	process.stderr.isTTY = false;
+	var stderrRes = requireUncached('./')(process.stderr);
+	assert.equal(Boolean(stderrRes), false);
+});
+
+it('should allow testing of individual streams', function () {
+	process.env = {TERM: 'xterm-256color'};
+	process.stderr.isTTY = false;
+	var supportsColor = requireUncached('./');
+	var stderrRes = supportsColor(process.stderr);
+	var stdoutRes = supportsColor(process.stdout);
+	assert.equal(Boolean(stderrRes), false);
+	assert.equal(Boolean(stdoutRes), true);
 });


### PR DESCRIPTION
This is big change that changes supports-color into a function that can be reused for tests many different streams. 

This allows the usecase I described in #42, but it is a semver major change because this changes how this module is used/called.

This could also be used by chalk itself to allow users to instantiate chalk while specifying the stream they will be writing to with that instance.