### PR TITLE
Use terminfo for TERM variable resolution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 sudo: false
 language: node_js
+addons:
+  apt:
+    packages:
+      - ncurses-base
 node_js:
   - 'stable'
   - '0.12'

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ node_js:
   - '0.10'
   - '0.8'
 before_install:
+  - toe
   - npm install -g npm@2
 script:
   - npm run travis

--- a/index.js
+++ b/index.js
@@ -58,20 +58,19 @@ var supportLevel = (function () {
 		return process.env.TEAMCITY_VERSION.match(/^(9\.(0*[1-9]\d*)\.|\d{2,}\.)/) === null ? 0 : 1;
 	}
 
-	if (/^(screen|xterm)-256(?:color)?/.test(process.env.TERM)) {
-		return 2;
-	}
-
-	if (/^screen|^xterm|^vt100|color|ansi|cygwin|linux/i.test(process.env.TERM)) {
-		return 1;
+	if ('TERM' in process.env) {
+		try {
+			var colors = require('terminfo')().maxColors;
+			if (colors && colors >= 8) {
+				return Math.floor((colors - 8) / (256 - 8)) + 1;
+			}
+		} catch (err) {
+			// swallow; it's an invalid terminal name
+		}
 	}
 
 	if ('COLORTERM' in process.env) {
 		return 1;
-	}
-
-	if (process.env.TERM === 'dumb') {
-		return 0;
 	}
 
 	return 0;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,8 @@
     "million"
   ],
   "dependencies": {
-    "has-flag": "^1.0.0"
+    "has-flag": "^1.0.0",
+    "terminfo": "^0.1.1"
   },
   "devDependencies": {
     "mocha": "*",

--- a/test.js
+++ b/test.js
@@ -162,3 +162,33 @@ it('should support screen-256color', function () {
 	var result = requireUncached('./');
 	assert.equal(result.level, 2);
 });
+
+it('should return 0 if an invalid terminal is given', function () {
+	process.env = {TERM: 'FOOBARMCGEE'};
+	var result = requireUncached('./');
+	assert.equal(Boolean(result), false);
+});
+
+it('should return a level of 2 for xterm-256color', function () {
+	process.env = {TERM: 'xterm-256color'};
+	var result = requireUncached('./');
+	assert.equal(result.level, 2);
+});
+
+it('should return a level of 1 for xterm', function () {
+	process.env = {TERM: 'xterm'};
+	var result = requireUncached('./');
+	assert.equal(result.level, 1);
+});
+
+it('should return a level of 1 for konsole-16color', function () {
+	process.env = {TERM: 'konsole-16color'};
+	var result = requireUncached('./');
+	assert.equal(result.level, 1);
+});
+
+it('should return a level of 2 for konsole-256color', function () {
+	process.env = {TERM: 'konsole-256color'};
+	var result = requireUncached('./');
+	assert.equal(result.level, 2);
+});


### PR DESCRIPTION
This would close #29.

This is a backwards-compatible inclusion of the [`terminfo`](https://npmjs.org/package/terminfo) package that reads the ncurses terminfo database present on all unix-based systems to determine color support.

It's pretty lightweight and has the added benefit of removing the need to do all of the ugly regex checks for the `TERM` variable.

The downside, of course, is that `supports-color` would then have a dependency, albeit one that is lightweight.

I'm okay if this gets shot down, I just wanted to have people see the change it'd require prior to making a final decision.

To be quite honest, it's pretty unintrusive - it could probably be released as a minor bump.