### PR TITLE
Support 256 color output on Windows 10

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,12 +47,10 @@ let supportLevel = (() => {
 
 	if (process.platform === 'win32') {
 		// Node.js 7.5.0 is the first version of Node.js to include a patch to
-		// libuv that enables color output on Windows. Anything earlier and it
-		// won't work. However, here we target 8.0.0 at minimum as it is an LTE
-		// release, and 7.x is not.
-		//
-		// Windows 10 build 10586 is the first Windows release that supports
-		// ANSI output and 256 console colors.
+		// libuv that enables 256 color output on Windows. Anything earlier and it
+		// won't work. However, here we target Node.js 8 at minimum as it is an LTS
+		// release, and Node.js 7 is not. Windows 10 build 10586 is the first Windows
+		// release that supports 256 colors.
 		const osRelease = os.release().split('.');
 		if (
 			Number(process.version.split('.')[0]) >= 8 &&
@@ -61,6 +59,7 @@ let supportLevel = (() => {
 		) {
 			return 2;
 		}
+
 		return 1;
 	}
 

--- a/index.js
+++ b/index.js
@@ -49,12 +49,13 @@ let supportLevel = (() => {
 	if (process.platform === 'win32') {
 		// Node.js 7.5.0 is the first version of Node.js to include a patch to
 		// libuv that enables color output on Windows. Anything earlier and it
-		// won't work.
+		// won't work. However, here we target 8.0.0 at minimum as it is an LTE
+		// release, and 7.x is not.
 		//
 		// Windows 10 build 10586 is the first Windows release that supports
 		// ANSI output and 256 console colors.
 		if (
-			semver.gte(process.version, '7.5.0') &&
+			semver.gte(process.version, '8.0.0') &&
 			semver.gte(os.release(), '10.0.10586')
 		) {
 			return 2;

--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 'use strict';
 const os = require('os');
 const hasFlag = require('has-flag');
-const semver = require('semver');
 
 const env = process.env;
 
@@ -54,9 +53,11 @@ let supportLevel = (() => {
 		//
 		// Windows 10 build 10586 is the first Windows release that supports
 		// ANSI output and 256 console colors.
+		const osRelease = os.release().split('.');
 		if (
-			semver.gte(process.version, '8.0.0') &&
-			semver.gte(os.release(), '10.0.10586')
+			Number(process.version.split('.')[0]) >= 8 &&
+			Number(osRelease[0]) >= 10 &&
+			Number(osRelease[2]) >= 10586
 		) {
 			return 2;
 		}

--- a/index.js
+++ b/index.js
@@ -47,13 +47,16 @@ let supportLevel = (() => {
 	}
 
 	if (process.platform === 'win32') {
-		// First version of Node.js to include patch to libuv that enables color
-		// output on Windows. Anything earlier and it won't work.
-		if (semver.lt(process.version, '7.5.0')) {
-			return 1;
-		}
-		// First Windows release that supports ANSI output and 256 console colors
-		if (semver.gte(os.release(), '10.0.10586')) {
+		// Node.js 7.5.0 is the first version of Node.js to include a patch to
+		// libuv that enables color output on Windows. Anything earlier and it
+		// won't work.
+		//
+		// Windows 10 build 10586 is the first Windows release that supports
+		// ANSI output and 256 console colors.
+		if (
+			semver.gte(process.version, '7.5.0') &&
+			semver.gte(os.release(), '10.0.10586')
+		) {
 			return 2;
 		}
 		return 1;

--- a/index.js
+++ b/index.js
@@ -47,12 +47,12 @@ let supportLevel = (() => {
 	}
 
 	if (process.platform === 'win32') {
-		// First version of Node.js to include patch to libuv that enables colour
+		// First version of Node.js to include patch to libuv that enables color
 		// output on Windows. Anything earlier and it won't work.
 		if (semver.lt(process.version, '7.5.0')) {
 			return 1;
 		}
-		// First Windows release that supports ANSI output and 256 console colours
+		// First Windows release that supports ANSI output and 256 console colors
 		if (semver.gte(os.release(), '10.0.10586')) {
 			return 2;
 		}

--- a/index.js
+++ b/index.js
@@ -1,5 +1,7 @@
 'use strict';
+const os = require('os');
 const hasFlag = require('has-flag');
+const semver = require('semver');
 
 const env = process.env;
 
@@ -45,6 +47,15 @@ let supportLevel = (() => {
 	}
 
 	if (process.platform === 'win32') {
+		// First version of Node.js to include patch to libuv that enables colour
+		// output on Windows. Anything earlier and it won't work.
+		if (semver.lt(process.version, '7.5.0')) {
+			return 1;
+		}
+		// First Windows release that supports ANSI output and 256 console colours
+		if (semver.gte(os.release(), '10.0.10586')) {
+			return 2;
+		}
 		return 1;
 	}
 

--- a/package.json
+++ b/package.json
@@ -42,8 +42,7 @@
     "16m"
   ],
   "dependencies": {
-    "has-flag": "^2.0.0",
-    "semver": "^5.3.0"
+    "has-flag": "^2.0.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "16m"
   ],
   "dependencies": {
-    "has-flag": "^2.0.0"
+    "has-flag": "^2.0.0",
+    "semver": "^5.3.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/test.js
+++ b/test.js
@@ -212,48 +212,48 @@ test('level should be 2 when using iTerm 2.9', t => {
 	t.is(result.level, 2);
 });
 
-test('return level 1 if on Windows earlier than 10 build 10586 and Node version is < 7.5.0', t => {
+test('return level 1 if on Windows earlier than 10 build 10586 and Node version is < 8.0.0', t => {
 	Object.defineProperty(process, 'platform', {
 		value: 'win32'
 	});
 	Object.defineProperty(process, 'version', {
-		value: '7.4.0'
+		value: '7.5.0'
 	});
 	os.release = () => '10.0.10240';
 	const result = importFresh('.');
 	t.is(result.level, 1);
 });
 
-test('return level 1 if on Windows 10 build 10586 or later and Node version is < 7.5.0', t => {
+test('return level 1 if on Windows 10 build 10586 or later and Node version is < 8.0.0', t => {
 	Object.defineProperty(process, 'platform', {
 		value: 'win32'
 	});
 	Object.defineProperty(process, 'version', {
-		value: '7.4.0'
+		value: '7.5.0'
 	});
 	os.release = () => '10.0.10586';
 	const result = importFresh('.');
 	t.is(result.level, 1);
 });
 
-test('return level 1 if on Windows earlier than 10 build 10586 and Node version is >= 7.5.0', t => {
+test('return level 1 if on Windows earlier than 10 build 10586 and Node version is >= 8.0.0', t => {
 	Object.defineProperty(process, 'platform', {
 		value: 'win32'
 	});
 	Object.defineProperty(process, 'version', {
-		value: '7.5.0'
+		value: '8.0.0'
 	});
 	os.release = () => '10.0.10240';
 	const result = importFresh('.');
 	t.is(result.level, 1);
 });
 
-test('return level 2 if on Windows 10 build 10586 or later and Node version is >= 7.5.0', t => {
+test('return level 2 if on Windows 10 build 10586 or later and Node version is >= 8.0.0', t => {
 	Object.defineProperty(process, 'platform', {
 		value: 'win32'
 	});
 	Object.defineProperty(process, 'version', {
-		value: '7.5.0'
+		value: '8.0.0'
 	});
 	os.release = () => '10.0.10586';
 	const result = importFresh('.');

--- a/test.js
+++ b/test.js
@@ -1,3 +1,4 @@
+import os from 'os';
 import {serial as test} from 'ava';
 import importFresh from 'import-fresh';
 
@@ -207,6 +208,54 @@ test('level should be 2 when using iTerm 2.9', t => {
 		TERM_PROGRAM: 'iTerm.app',
 		TERM_PROGRAM_VERSION: '2.9.3'
 	};
+	const result = importFresh('.');
+	t.is(result.level, 2);
+});
+
+test('return level 1 if on Windows earlier than 10 build 10586 and Node version is < 7.5.0', t => {
+	Object.defineProperty(process, 'platform', {
+		value: 'win32'
+	});
+	Object.defineProperty(process, 'version', {
+		value: '7.4.0'
+	});
+	os.release = () => '10.0.10240';
+	const result = importFresh('.');
+	t.is(result.level, 1);
+});
+
+test('return level 1 if on Windows 10 build 10586 or later and Node version is < 7.5.0', t => {
+	Object.defineProperty(process, 'platform', {
+		value: 'win32'
+	});
+	Object.defineProperty(process, 'version', {
+		value: '7.4.0'
+	});
+	os.release = () => '10.0.10586';
+	const result = importFresh('.');
+	t.is(result.level, 1);
+});
+
+test('return level 1 if on Windows earlier than 10 build 10586 and Node version is >= 7.5.0', t => {
+	Object.defineProperty(process, 'platform', {
+		value: 'win32'
+	});
+	Object.defineProperty(process, 'version', {
+		value: '7.5.0'
+	});
+	os.release = () => '10.0.10240';
+	const result = importFresh('.');
+	t.is(result.level, 1);
+});
+
+test('return level 2 if on Windows 10 build 10586 or later and Node version is >= 7.5.0', t => {
+	Object.defineProperty(process, 'platform', {
+		value: 'win32'
+	});
+	Object.defineProperty(process, 'version', {
+		value: '7.5.0'
+	});
+	os.release = () => '10.0.10586';
 	const result = importFresh('.');
 	t.is(result.level, 2);
 });

--- a/test.js
+++ b/test.js
@@ -2,6 +2,9 @@ import {serial as test} from 'ava';
 import importFresh from 'import-fresh';
 
 test.beforeEach(() => {
+	Object.defineProperty(process, 'platform', {
+		value: 'linux'
+	});
 	process.stdout.isTTY = true;
 	process.argv = [];
 	process.env = {};
@@ -185,6 +188,9 @@ test('support screen-256color', t => {
 });
 
 test('level should be 3 when using iTerm 3.0', t => {
+	Object.defineProperty(process, 'platform', {
+		value: 'darwin'
+	});
 	process.env = {
 		TERM_PROGRAM: 'iTerm.app',
 		TERM_PROGRAM_VERSION: '3.0.10'
@@ -194,6 +200,9 @@ test('level should be 3 when using iTerm 3.0', t => {
 });
 
 test('level should be 2 when using iTerm 2.9', t => {
+	Object.defineProperty(process, 'platform', {
+		value: 'darwin'
+	});
 	process.env = {
 		TERM_PROGRAM: 'iTerm.app',
 		TERM_PROGRAM_VERSION: '2.9.3'


### PR DESCRIPTION
Fixes #49

Returns support level 2 (256-bit colour) if running on Windows 10 build 10586 or later and Node.js 7.5.0 or later. Node.js 7.5.0 is the first version of Node.js to include the [libuv patch](https://github.com/libuv/libuv/commit/445e3a1f06b2a049e2b50b7edf2992ce80167014) that enables ANSI support on Windows 10.

- Added checks for Windows
- Fixed existing tests on Windows
- Added new tests to test Windows platform behaviour

Tests ran successfully on Windows and Linux.