### PR TITLE
Add support for putty-256color terminfo

### DIFF
--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ let supportLevel = (() => {
 		}
 	}
 
-	if (/^(screen|xterm|putty)-256(?:color)?/.test(env.TERM)) {
+	if (/-256(color)?$/i.test(env.TERM)) {
 		return 2;
 	}
 

--- a/index.js
+++ b/index.js
@@ -89,7 +89,7 @@ let supportLevel = (() => {
 		}
 	}
 
-	if (/^(screen|xterm)-256(?:color)?/.test(env.TERM)) {
+	if (/^(screen|xterm|putty)-256(?:color)?/.test(env.TERM)) {
 		return 2;
 	}
 

--- a/test.js
+++ b/test.js
@@ -194,6 +194,12 @@ test('support screen-256color', t => {
 	t.is(result.level, 2);
 });
 
+test('support putty-256color', t => {
+	process.env = {TERM: 'putty-256color'};
+	const result = importFresh('.');
+	t.is(result.level, 2);
+});
+
 test('level should be 3 when using iTerm 3.0', t => {
 	Object.defineProperty(process, 'platform', {
 		value: 'darwin'


### PR DESCRIPTION
There is a putty-256color terminfo on ubuntu (and probably other systems) that allows for the minor differences between putty and xterm. However currently this fails to then register the support with supports-color / chalk because it's specifically looking for xterm-256color or screen-256color.

This just extends the regex to also match putty-256color.

I'm not sure if it might be better to instead just match on env.TERM ending with 256 color? That could product some unexpected false positives, so I didn't go that far.

Here is a list of terminfo matches on ubuntu14.04 as that happens to be the os of the server I'm connecting to.

    /$ find /usr/share/terminfo/ | grep 256color
    /usr/share/terminfo/E/Eterm-256color
    /usr/share/terminfo/x/xterm+256color
    /usr/share/terminfo/v/vte-256color
    /usr/share/terminfo/g/gnome-256color
    /usr/share/terminfo/n/nsterm-256color
    /usr/share/terminfo/r/rxvt-unicode-256color
    /usr/share/terminfo/r/rxvt-256color
    /usr/share/terminfo/p/putty-256color
    /usr/share/terminfo/k/konsole-256color
    /usr/share/terminfo/s/screen-256color-s
    /usr/share/terminfo/s/screen-256color-bce-s
    /usr/share/terminfo/m/mrxvt-256color
    /usr/share/terminfo/m/mlterm-256color
