### PR TITLE
Fix 256 color detection on Windows 10 

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ let supportLevel = (() => {
 		// release that supports 256 colors.
 		const osRelease = os.release().split('.');
 		if (
-			Number(process.version.split('.')[0]) >= 8 &&
+			Number(process.versions.node.split('.')[0]) >= 8 &&
 			Number(osRelease[0]) >= 10 &&
 			Number(osRelease[2]) >= 10586
 		) {

--- a/test.js
+++ b/test.js
@@ -218,11 +218,6 @@ test('level should be 2 when using iTerm 2.9', t => {
 	t.is(result.level, 2);
 });
 
-test('Get the correct version number of node', t => {
-	t.regex(process.versions.node, /^\d+/);
-	t.notRegex(process.version, /^\d+/);
-});
-
 test('return level 1 if on Windows earlier than 10 build 10586 and Node version is < 8.0.0', t => {
 	Object.defineProperty(process, 'platform', {
 		value: 'win32'

--- a/test.js
+++ b/test.js
@@ -218,6 +218,11 @@ test('level should be 2 when using iTerm 2.9', t => {
 	t.is(result.level, 2);
 });
 
+test('Get the correct version number of node', t => {
+	t.regex(process.versions.node, /^\d+/);
+	t.notRegex(process.version, /^\d+/);
+});
+
 test('return level 1 if on Windows earlier than 10 build 10586 and Node version is < 8.0.0', t => {
 	Object.defineProperty(process, 'platform', {
 		value: 'win32'

--- a/test.js
+++ b/test.js
@@ -222,7 +222,7 @@ test('return level 1 if on Windows earlier than 10 build 10586 and Node version 
 	Object.defineProperty(process, 'platform', {
 		value: 'win32'
 	});
-	Object.defineProperty(process, 'version', {
+	Object.defineProperty(process.versions, 'node', {
 		value: '7.5.0'
 	});
 	os.release = () => '10.0.10240';
@@ -234,7 +234,7 @@ test('return level 1 if on Windows 10 build 10586 or later and Node version is <
 	Object.defineProperty(process, 'platform', {
 		value: 'win32'
 	});
-	Object.defineProperty(process, 'version', {
+	Object.defineProperty(process.versions, 'node', {
 		value: '7.5.0'
 	});
 	os.release = () => '10.0.10586';
@@ -246,7 +246,7 @@ test('return level 1 if on Windows earlier than 10 build 10586 and Node version 
 	Object.defineProperty(process, 'platform', {
 		value: 'win32'
 	});
-	Object.defineProperty(process, 'version', {
+	Object.defineProperty(process.versions, 'node', {
 		value: '8.0.0'
 	});
 	os.release = () => '10.0.10240';
@@ -258,7 +258,7 @@ test('return level 2 if on Windows 10 build 10586 or later and Node version is >
 	Object.defineProperty(process, 'platform', {
 		value: 'win32'
 	});
-	Object.defineProperty(process, 'version', {
+	Object.defineProperty(process.versions, 'node', {
 		value: '8.0.0'
 	});
 	os.release = () => '10.0.10586';


### PR DESCRIPTION
Fixes #59

```bash
E:\work\supports-color (win10) (supports-color@4.2.0)
$ node -p process.version
v8.1.2

E:\work\supports-color (win10) (supports-color@4.2.0)
$ node -p process.versions.node
8.1.2

E:\work\supports-color (win10) (supports-color@4.2.0)
$ node -p require('./')
{ level: 2, hasBasic: true, has256: true, has16m: false }
```
`process.version` has a prefix `v`, so I use `process.versions.node` to replace it