### PR TITLE
Check for CI before isTTY

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,14 @@ let supportLevel = (() => {
 		return 1;
 	}
 
+	if ('CI' in env) {
+		if ('TRAVIS' in env || env.CI === 'Travis' || 'CIRCLECI' in env) {
+			return 1;
+		}
+
+		return 0;
+	}
+
 	if (process.stdout && !process.stdout.isTTY) {
 		return 0;
 	}
@@ -61,14 +69,6 @@ let supportLevel = (() => {
 		}
 
 		return 1;
-	}
-
-	if ('CI' in env) {
-		if ('TRAVIS' in env || env.CI === 'Travis' || 'CIRCLECI' in env) {
-			return 1;
-		}
-
-		return 0;
 	}
 
 	if ('TEAMCITY_VERSION' in env) {


### PR DESCRIPTION
TravisCI has some special logic in master builds that filters logs (to prevent ENV variables to be printed). This logic results in `process.stdout.isTTY` to be `false` (only in master branch builds, not in PR builds).

if we change the order these checks are done, we should be able to return consistent value on both master and PR builds on travis