### PR TITLE
Allow testing of individual streams

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const hasFlag = require('has-flag');
 
 const env = process.env;
 
-const support = level => {
+function translateLevel(level) {
 	if (level === 0) {
 		return false;
 	}
@@ -15,9 +15,9 @@ const support = level => {
 		has256: level >= 2,
 		has16m: level >= 3
 	};
-};
+}
 
-let supportLevel = (() => {
+function supportsColor(stream) {
 	if (hasFlag('no-color') ||
 		hasFlag('no-colors') ||
 		hasFlag('color=false')) {
@@ -41,7 +41,7 @@ let supportLevel = (() => {
 		return 1;
 	}
 
-	if (process.stdout && !process.stdout.isTTY) {
+	if (stream && !stream.isTTY) {
 		return 0;
 	}
 
@@ -106,10 +106,20 @@ let supportLevel = (() => {
 	}
 
 	return 0;
-})();
-
-if ('FORCE_COLOR' in env) {
-	supportLevel = parseInt(env.FORCE_COLOR, 10) === 0 ? 0 : (supportLevel || 1);
 }
 
-module.exports = process && support(supportLevel);
+function getSupportLevel(stream) {
+	let level = supportsColor(stream);
+
+	if ('FORCE_COLOR' in env) {
+		level = (env.FORCE_COLOR.length > 0 && parseInt(env.FORCE_COLOR, 10) === 0) ? 0 : (level || 1);
+	}
+
+	return translateLevel(level);
+}
+
+module.exports = {
+	supportsColor: getSupportLevel,
+	stdout: getSupportLevel(process.stdout),
+	stderr: getSupportLevel(process.stderr)
+};

--- a/test.js
+++ b/test.js
@@ -14,196 +14,196 @@ test.beforeEach(() => {
 test('return true if `FORCE_COLOR` is in env', t => {
 	process.env.FORCE_COLOR = true;
 	const result = importFresh('.');
-	t.truthy(result);
-	t.is(result.level, 1);
+	t.truthy(result.stdout);
+	t.is(result.stdout.level, 1);
 });
 
 test('return true if `FORCE_COLOR` is in env, but honor 256', t => {
 	process.argv = ['--color=256'];
 	process.env.FORCE_COLOR = true;
 	const result = importFresh('.');
-	t.truthy(result);
-	t.is(result.level, 2);
+	t.truthy(result.stdout);
+	t.is(result.stdout.level, 2);
 });
 
 test('return true if `FORCE_COLOR` is in env, but honor 256', t => {
 	process.argv = ['--color=256'];
 	process.env.FORCE_COLOR = '1';
 	const result = importFresh('.');
-	t.truthy(result);
-	t.is(result.level, 2);
+	t.truthy(result.stdout);
+	t.is(result.stdout.level, 2);
 });
 
 test('return false if `FORCE_COLOR` is in env and is 0', t => {
 	process.env.FORCE_COLOR = '0';
 	const result = importFresh('.');
-	t.false(result);
+	t.false(result.stdout);
 });
 
 test('return false if not TTY', t => {
 	process.stdout.isTTY = false;
 	const result = importFresh('.');
-	t.false(result);
+	t.false(result.stdout);
 });
 
 test('return false if --no-color flag is used', t => {
 	process.env = {TERM: 'xterm-256color'};
 	process.argv = ['--no-color'];
 	const result = importFresh('.');
-	t.false(result);
+	t.false(result.stdout);
 });
 
 test('return false if --no-colors flag is used', t => {
 	process.env = {TERM: 'xterm-256color'};
 	process.argv = ['--no-colors'];
 	const result = importFresh('.');
-	t.false(result);
+	t.false(result.stdout);
 });
 
 test('return true if --color flag is used', t => {
 	process.argv = ['--color'];
 	const result = importFresh('.');
-	t.truthy(result);
+	t.truthy(result.stdout);
 });
 
 test('return true if --colors flag is used', t => {
 	process.argv = ['--colors'];
 	const result = importFresh('.');
-	t.truthy(result);
+	t.truthy(result.stdout);
 });
 
 test('return true if `COLORTERM` is in env', t => {
 	process.env.COLORTERM = true;
 	const result = importFresh('.');
-	t.truthy(result);
+	t.truthy(result.stdout);
 });
 
 test('support `--color=true` flag', t => {
 	process.argv = ['--color=true'];
 	const result = importFresh('.');
-	t.truthy(result);
+	t.truthy(result.stdout);
 });
 
 test('support `--color=always` flag', t => {
 	process.argv = ['--color=always'];
 	const result = importFresh('.');
-	t.truthy(result);
+	t.truthy(result.stdout);
 });
 
 test('support `--color=false` flag', t => {
 	process.env = {TERM: 'xterm-256color'};
 	process.argv = ['--color=false'];
 	const result = importFresh('.');
-	t.false(result);
+	t.false(result.stdout);
 });
 
 test('support `--color=256` flag', t => {
 	process.argv = ['--color=256'];
 	const result = importFresh('.');
-	t.truthy(result);
+	t.truthy(result.stdout);
 });
 
 test('level should be 2 if `--color=256` flag is used', t => {
 	process.argv = ['--color=256'];
 	const result = importFresh('.');
-	t.is(result.level, 2);
-	t.true(result.has256);
+	t.is(result.stdout.level, 2);
+	t.true(result.stdout.has256);
 });
 
 test('support `--color=16m` flag', t => {
 	process.argv = ['--color=16m'];
 	const result = importFresh('.');
-	t.truthy(result);
+	t.truthy(result.stdout);
 });
 
 test('support `--color=full` flag', t => {
 	process.argv = ['--color=full'];
 	const result = importFresh('.');
-	t.truthy(result);
+	t.truthy(result.stdout);
 });
 
 test('support `--color=truecolor` flag', t => {
 	process.argv = ['--color=truecolor'];
 	const result = importFresh('.');
-	t.truthy(result);
+	t.truthy(result.stdout);
 });
 
 test('level should be 3 if `--color=16m` flag is used', t => {
 	process.argv = ['--color=16m'];
 	const result = importFresh('.');
-	t.is(result.level, 3);
-	t.true(result.has256);
-	t.true(result.has16m);
+	t.is(result.stdout.level, 3);
+	t.true(result.stdout.has256);
+	t.true(result.stdout.has16m);
 });
 
 test('ignore post-terminator flags', t => {
 	process.argv = ['--color', '--', '--no-color'];
 	const result = importFresh('.');
-	t.truthy(result);
+	t.truthy(result.stdout);
 });
 
 test('allow tests of the properties on false', t => {
 	process.env = {TERM: 'xterm-256color'};
 	process.argv = ['--no-color'];
 	const result = importFresh('.');
-	t.is(result.hasBasic, undefined);
-	t.is(result.has256, undefined);
-	t.is(result.has16m, undefined);
-	t.false(result.level > 0);
+	t.is(result.stdout.hasBasic, undefined);
+	t.is(result.stdout.has256, undefined);
+	t.is(result.stdout.has16m, undefined);
+	t.false(result.stdout.level > 0);
 });
 
 test('return false if `CI` is in env', t => {
 	process.env.CI = 'AppVeyor';
 	const result = importFresh('.');
-	t.false(result);
+	t.false(result.stdout);
 });
 
 test('return true if `TRAVIS` is in env', t => {
 	process.env = {CI: 'Travis', TRAVIS: '1'};
 	const result = importFresh('.');
-	t.truthy(result);
+	t.truthy(result.stdout);
 });
 
 test('return true if `CIRCLECI` is in env', t => {
 	process.env = {CI: true, CIRCLECI: true};
 	const result = importFresh('.');
-	t.truthy(result);
+	t.truthy(result.stdout);
 });
 
 test('return true if `APPVEYOR` is in env', t => {
 	process.env = {CI: true, APPVEYOR: true};
 	const result = importFresh('.');
-	t.truthy(result);
+	t.truthy(result.stdout);
 });
 
 test('return true if `GITLAB_CI` is in env', t => {
 	process.env = {CI: true, GITLAB_CI: true};
 	const result = importFresh('.');
-	t.truthy(result);
+	t.truthy(result.stdout);
 });
 
 test('return false if `TEAMCITY_VERSION` is in env and is < 9.1', t => {
 	process.env.TEAMCITY_VERSION = '9.0.5 (build 32523)';
 	const result = importFresh('.');
-	t.false(result);
+	t.false(result.stdout);
 });
 
 test('return level 1 if `TEAMCITY_VERSION` is in env and is >= 9.1', t => {
 	process.env.TEAMCITY_VERSION = '9.1.0 (build 32523)';
 	const result = importFresh('.');
-	t.is(result.level, 1);
+	t.is(result.stdout.level, 1);
 });
 
 test('prefer level 2/xterm over COLORTERM', t => {
 	process.env = {COLORTERM: '1', TERM: 'xterm-256color'};
 	const result = importFresh('.');
-	t.is(result.level, 2);
+	t.is(result.stdout.level, 2);
 });
 
 test('support screen-256color', t => {
 	process.env = {TERM: 'screen-256color'};
 	const result = importFresh('.');
-	t.is(result.level, 2);
+	t.is(result.stdout.level, 2);
 });
 
 test('level should be 3 when using iTerm 3.0', t => {
@@ -215,7 +215,7 @@ test('level should be 3 when using iTerm 3.0', t => {
 		TERM_PROGRAM_VERSION: '3.0.10'
 	};
 	const result = importFresh('.');
-	t.is(result.level, 3);
+	t.is(result.stdout.level, 3);
 });
 
 test('level should be 2 when using iTerm 2.9', t => {
@@ -227,7 +227,7 @@ test('level should be 2 when using iTerm 2.9', t => {
 		TERM_PROGRAM_VERSION: '2.9.3'
 	};
 	const result = importFresh('.');
-	t.is(result.level, 2);
+	t.is(result.stdout.level, 2);
 });
 
 test('return level 1 if on Windows earlier than 10 build 10586 and Node version is < 8.0.0', t => {
@@ -239,7 +239,7 @@ test('return level 1 if on Windows earlier than 10 build 10586 and Node version 
 	});
 	os.release = () => '10.0.10240';
 	const result = importFresh('.');
-	t.is(result.level, 1);
+	t.is(result.stdout.level, 1);
 });
 
 test('return level 1 if on Windows 10 build 10586 or later and Node version is < 8.0.0', t => {
@@ -251,7 +251,7 @@ test('return level 1 if on Windows 10 build 10586 or later and Node version is <
 	});
 	os.release = () => '10.0.10586';
 	const result = importFresh('.');
-	t.is(result.level, 1);
+	t.is(result.stdout.level, 1);
 });
 
 test('return level 1 if on Windows earlier than 10 build 10586 and Node version is >= 8.0.0', t => {
@@ -263,7 +263,7 @@ test('return level 1 if on Windows earlier than 10 build 10586 and Node version 
 	});
 	os.release = () => '10.0.10240';
 	const result = importFresh('.');
-	t.is(result.level, 1);
+	t.is(result.stdout.level, 1);
 });
 
 test('return level 2 if on Windows 10 build 10586 or later and Node version is >= 8.0.0', t => {
@@ -275,5 +275,5 @@ test('return level 2 if on Windows 10 build 10586 or later and Node version is >
 	});
 	os.release = () => '10.0.10586';
 	const result = importFresh('.');
-	t.is(result.level, 2);
+	t.is(result.stdout.level, 2);
 });


### PR DESCRIPTION
Closes #51. This is a breaking change.

---

This PR adds the ability to test individual output streams for validity. This is one particular approach - see the end of this PR for another non-breaking proposed approach.

This exposes the new API as:

```javascript
const supportsColor = {
    supportsColor: (stream) => {...},
    stdout: supportsColor(process.stdout),
    stderr: supportsColor(process.stderr)
}
```

So the only change necessary to migrate would be to change

```javascript
const supportsColor = require('supports-color');

if (supportsColor) {
    // ...
}

if (supportsColor.level >= 2) {
    // ...
}
```

to either

```javascript
const supportsColor = require('supports-color');

if (supportsColor.stdout) {
    // ...
}

if (supportsColor.stdout.level >= 2) {
    // ...
}
```

or simply

```javascript
const supportsColor = require('supports-color').stdout;
```

---

So as I mentioned earlier, this is one of two possible ways we can approach this problem. In my opinion, this PR is the *correct* way to approach the problem, albeit a breaking change.

However, the alternative would be to introduce a second script that can be included directly:

```javascript
const stderrSupportsColor = require('supports-color/stream')(process.stderr);
```

Though philosophically that is a bandaid fix, I foresee this package going away sometime within the next few years due to progress in the TTY realm, so I feel much less strongly about the approach itself.

If this is the route we want to take as opposed to this PR, that's totally fine - just let me know.