### PR TITLE
Calculate proper `level` when forcing color

### DIFF
--- a/test.js
+++ b/test.js
@@ -12,6 +12,7 @@ test.beforeEach(() => {
 });
 
 test('return true if `FORCE_COLOR` is in env', t => {
+	process.stdout.isTTY = false;
 	process.env.FORCE_COLOR = true;
 	const result = importFresh('.');
 	t.truthy(result.stdout);
@@ -306,4 +307,13 @@ test('return level 3 if on Windows 10 build 14931 or later and Node version is >
 	os.release = () => '10.0.14931';
 	const result = importFresh('.');
 	t.is(result.stdout.level, 3);
+});
+
+test('return level 2 when FORCE_COLOR is set when not TTY in xterm256', t => {
+	process.stdout.isTTY = false;
+	process.env.FORCE_COLOR = true;
+	process.env.TERM = 'xterm-256color';
+	const result = importFresh('.');
+	t.truthy(result.stdout);
+	t.is(result.stdout.level, 2);
 });


### PR DESCRIPTION
Before, the level would be 1 when forcing color when the stream is not a TTY.

```
$ FORCE_COLOR=1 node -p "require('supports-color').stdout" | cat
{ level: 1, hasBasic: true, has256: false, has16m: false }`
```

Now, the proper level is calculated based on the environment, even when the stream is not a TTY.

```
$ FORCE_COLOR=1 node -p "require('supports-color').stdout" | cat
{ level: 3, hasBasic: true, has256: true, has16m: true }
```