### PR TITLE
Check the COLORTERM variable for 16M color support

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ function supportsColor(stream) {
 	if ('TEAMCITY_VERSION' in env) {
 		return /^(9\.(0*[1-9]\d*)\.|\d{2,}\.)/.test(env.TEAMCITY_VERSION) ? 1 : 0;
 	}
-	
+
 	if (env.COLORTERM === 'truecolor') {
 		return 3;
 	}

--- a/index.js
+++ b/index.js
@@ -83,6 +83,10 @@ function supportsColor(stream) {
 	if ('TEAMCITY_VERSION' in env) {
 		return /^(9\.(0*[1-9]\d*)\.|\d{2,}\.)/.test(env.TEAMCITY_VERSION) ? 1 : 0;
 	}
+	
+	if (env.COLORTERM === 'truecolor') {
+		return 3;
+	}
 
 	if ('TERM_PROGRAM' in env) {
 		const version = parseInt((env.TERM_PROGRAM_VERSION || '').split('.')[0], 10);


### PR DESCRIPTION
According to https://gist.github.com/XVilka/8346728#detection and empirical tests on Konsole,
when `COLORTERM=truecolor`, 24-bit color support is guaranteed to work.