### PR TITLE
Remove now moot VSCode check

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,10 +48,6 @@ function supportsColor(stream) {
 	}
 
 	if (stream && !stream.isTTY && forceColor !== true) {
-		// VS code debugger doesn't have isTTY set
-		if (env.VSCODE_PID) {
-			return 1;
-		}
 		return 0;
 	}
 


### PR DESCRIPTION
VSCode appears to now set stream.isTTY in the debugger.

Fixes #79 