### PR TITLE
Add support for VT220

### DIFF
--- a/index.js
+++ b/index.js
@@ -104,7 +104,7 @@ function supportsColor(stream) {
 		return 2;
 	}
 
-	if (/^screen|^xterm|^vt100|^rxvt|color|ansi|cygwin|linux/i.test(env.TERM)) {
+	if (/^screen|^xterm|^vt100|^vt220|^rxvt|color|ansi|cygwin|linux/i.test(env.TERM)) {
 		return 1;
 	}
 


### PR DESCRIPTION
This PR adds [`vt220`](https://en.wikipedia.org/wiki/VT220) to the list of supported terminals, used by OpenBSD (and NetBSD, IIRC) when running in console mode:

For reference, here's proof (sorry for the blurry phone picture, taking screenshots of consoles isn't that easy 😉):

<img src="https://user-images.githubusercontent.com/2346707/44204630-b940d400-a196-11e8-9dd8-c822d8785b44.jpg" width="650" alt="Figure 1" />