### PR TITLE
Remove hasFlag npm dependency by inlining it in index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 const os = require('os');
-const hasFlag = require('has-flag');
 
 const env = process.env;
 
@@ -122,6 +121,14 @@ function supportsColor(stream) {
 function getSupportLevel(stream) {
 	const level = supportsColor(stream);
 	return translateLevel(level);
+}
+
+function hasFlag(flag, argv) {
+	argv = argv || process.argv;
+	const prefix = flag.startsWith('-') ? '' : (flag.length === 1 ? '-' : '--');
+	const pos = argv.indexOf(prefix + flag);
+	const terminatorPos = argv.indexOf('--');
+	return pos !== -1 && (terminatorPos === -1 ? true : pos < terminatorPos);
 }
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -41,9 +41,6 @@
 		"truecolor",
 		"16m"
 	],
-	"dependencies": {
-		"has-flag": "^3.0.0"
-	},
 	"devDependencies": {
 		"ava": "^0.25.0",
 		"import-fresh": "^2.0.0",


### PR DESCRIPTION
Hi all, 

after another [NPM fiasco](https://www.reddit.com/r/programming/comments/a0kxmw/i_dont_know_what_to_say_backdoor_in_popular/) I decided to check the dependencies of some of my favorite packages. Hoping to lower the number of dependencies they have by eliminating some of the trivial NPM packages they rely on. 

This package is the first on my quest. I hope you think this is okay. 