### PR TITLE
Be smarter about “dumb” terminals

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,6 +53,10 @@ function supportsColor(stream) {
 
 	const min = forceColor ? 1 : 0;
 
+	if (env.TERM === 'dumb') {
+		return min;
+	}
+
 	if (process.platform === 'win32') {
 		// Node.js 7.5.0 is the first version of Node.js to include a patch to
 		// libuv that enables 256 color output on Windows. Anything earlier and it
@@ -110,10 +114,6 @@ function supportsColor(stream) {
 
 	if ('COLORTERM' in env) {
 		return 1;
-	}
-
-	if (env.TERM === 'dumb') {
-		return min;
 	}
 
 	return min;


### PR DESCRIPTION
When terminals are declared as "dumb", it means the author doesn't want/expect anything other than plain-text output. There's usually a damn good reason for this — we should treat `TERM=dumb`  as meaning `FORCE_COLOR=0`, instead of [imagining this](https://imgur.com/gallery/NLsrB).

**Fixes:** [`chalk/supports-color#88`](https://github.com/chalk/supports-color/issues/88)
**Related:** [`mochajs/mocha#1304`](https://github.com/mochajs/mocha/issues/1304#issuecomment-443460343), [`emacs.stackexchange.com/q/27218`](https://emacs.stackexchange.com/questions/27218/why-is-there-so-often-ugly-output-in-node-js-compilation-buffers)

### Emacs `compile` command — Before and after:

<img src="https://user-images.githubusercontent.com/2346707/49336453-b7702300-f656-11e8-849b-5df189dcea32.png" alt="Emacs compilation-mode: Before" width="45%"  valign="middle" /> <img src="https://user-images.githubusercontent.com/2346707/49336471-ec7c7580-f656-11e8-8e48-4683f02df619.png" alt="Emacs compilation-mode: After" width="45%"  valign="middle" />

@plroebuck As you can see, it seems some changes are still required elsewhere to clean up the stack-trace highlighting. 

This fix has the unfortunate effect of impacting Emacs commands which *do* colourise output directly, such as [`mocha.el`](https://github.com/scottaj/mocha.el)'s `(mocha-test-project)` command:

### `mocha.el` — Before and after:

<img src="https://user-images.githubusercontent.com/2346707/49336492-572db100-f657-11e8-96fc-623bc9ae0803.png" width="45%" alt="Mocha.el: Before" valign="top" /> <img src="https://user-images.githubusercontent.com/2346707/49336502-6dd40800-f657-11e8-8bb7-019d7f6eaf53.png" alt="Mocha.el: After" width="45%" valign="top" />

Authors can always fix this by forcing colours in their environments, though, so this shouldn't be a problem in the long-run.