### PR TITLE
Add support for `color=never` CLI flag

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,8 @@ const {env} = process;
 let forceColor;
 if (hasFlag('no-color') ||
 	hasFlag('no-colors') ||
-	hasFlag('color=false')) {
+	hasFlag('color=false') ||
+	hasFlag('color=never')) {
 	forceColor = 0;
 } else if (hasFlag('color') ||
 	hasFlag('colors') ||


### PR DESCRIPTION
Your code has support for `always`, it seems expected that `never` would work too.

I would like to use these as flags, they seem standard and have been included in `grep`
```
     --colour=[when, --color=[when]]
             Mark up the matching text with the expression stored in GREP_COLOR environment variable.  The possible values of when can be `never', `always' or
             `auto'.
```