### PR TITLE
Add node v9 color depth support

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,6 +55,18 @@ function supportsColor(stream) {
 		return 2;
 	}
 
+	const colorDepth = stream.getColorDepth && stream.getColorDepth(process.env);
+	if (colorDepth && forceColor === undefined) {
+		switch (colorDepth) {
+			case 1: return 0;
+			case 4: return 1;
+			case 8: return 2;
+			case 24: return 3;
+			default:
+				break;
+		}
+	}
+
 	if (stream && !stream.isTTY && forceColor === undefined) {
 		return 0;
 	}

--- a/test.js
+++ b/test.js
@@ -16,6 +16,9 @@ test.beforeEach(() => {
 	process.stdout.isTTY = true;
 	process.argv = [];
 	process.env = {};
+
+	process.stdout._getColorDepth = process.stdout.getColorDepth;
+	process.stdout.getColorDepth = null;
 });
 
 // FIXME
@@ -382,4 +385,29 @@ test('return level 1 when `TERM` is set to dumb when `FORCE_COLOR` is set', t =>
 	const result = importFresh('.');
 	t.truthy(result.stdout);
 	t.is(result.stdout.level, 1);
+});
+
+test('getColorDepth() is used if available', t => {
+	process.stdout.getColorDepth = null;
+	process.stdout.isTTY = false;
+	let result = importFresh('.');
+	t.is(result.stdout, false);
+
+	process.stdout.isTTY = true;
+	process.stdout.getColorDepth = () => 2;
+	result = importFresh('.');
+	t.is(result.stdout, false);
+
+	process.stdout.isTTY = false;
+	process.stdout.getColorDepth = () => 4;
+	result = importFresh('.');
+	t.is(result.stdout.level, 1);
+
+	process.stdout.getColorDepth = () => 8;
+	result = importFresh('.');
+	t.is(result.stdout.level, 2);
+
+	process.stdout.getColorDepth = () => 24;
+	result = importFresh('.');
+	t.is(result.stdout.level, 3);
 });


### PR DESCRIPTION
Closes #98.

No need to use `.hasColors()` as it's a [small wrapper](https://github.com/nodejs/node/pull/26247) around `.getColorDepth()`, which is supported in an older version of Node anyway - so it's a win win.