### PR TITLE
Add option for ignoring `process.argv`

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,6 +40,15 @@ The `stdout`/`stderr` objects specifies a level of support for color through a `
 - `.level = 3` and `.has16m = true`: Truecolor support (16 million colors)
 
 
+### `require('supports-color').supportsColor(stream, options?)`
+
+Additionally, `supports-color` exposes the `.supportsColor()` function that takes an arbitrary write stream (e.g. `process.stdout`) and an optional options object to (re-)evaluate color support for an arbitrary stream.
+
+For example, `require('supports-color').stdout` is the equivalent of `require('supports-color').supportsColor(process.stdout)`.
+
+The options object supports a single boolean property `sniffFlags`. By default it is `true`, which instructs `supportsColor()` to sniff `process.argv` for the multitude of `--color` flags (see _Info_ below). If `false`, then `process.argv` is not considered when determining color support.
+
+
 ## Info
 
 It obeys the `--color` and `--no-color` CLI flags.

--- a/test.js
+++ b/test.js
@@ -389,3 +389,19 @@ test('return level 1 when `TERM` is set to dumb when `FORCE_COLOR` is set', t =>
 	t.truthy(result.stdout);
 	t.is(result.stdout.level, 1);
 });
+
+test('ignore flags when sniffFlags=false', t => {
+	process.argv = ['--color=256'];
+	process.env.TERM = 'dumb';
+	const result = importFresh('.');
+
+	t.truthy(result.stdout);
+	t.is(result.stdout.level, 2);
+
+	const sniffResult = result.supportsColor(process.stdout, {sniffFlags: true});
+	t.truthy(sniffResult);
+	t.is(sniffResult.level, 2);
+
+	const nosniffResult = result.supportsColor(process.stdout, {sniffFlags: false});
+	t.falsy(nosniffResult);
+});


### PR DESCRIPTION
Closes #40.

Also adds documentation for the previously undocumented `.supportsColor` function.