### PR TITLE
Avoid triggering stdio streams creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 'use strict';
 const os = require('os');
+const tty = require('tty');
 const hasFlag = require('has-flag');
 
 const {env} = process;
@@ -40,7 +41,7 @@ function translateLevel(level) {
 	};
 }
 
-function supportsColor(stream) {
+function supportsColor(haveStream, streamIsTTY) {
 	if (forceColor === 0) {
 		return 0;
 	}
@@ -55,7 +56,7 @@ function supportsColor(stream) {
 		return 2;
 	}
 
-	if (stream && !stream.isTTY && forceColor === undefined) {
+	if (haveStream && !streamIsTTY && forceColor === undefined) {
 		return 0;
 	}
 
@@ -123,12 +124,12 @@ function supportsColor(stream) {
 }
 
 function getSupportLevel(stream) {
-	const level = supportsColor(stream);
+	const level = supportsColor(stream, stream && stream.isTTY);
 	return translateLevel(level);
 }
 
 module.exports = {
 	supportsColor: getSupportLevel,
-	stdout: getSupportLevel(process.stdout),
-	stderr: getSupportLevel(process.stderr)
+	stdout: translateLevel(supportsColor(true, tty.isatty(1))),
+	stderr: translateLevel(supportsColor(true, tty.isatty(2)))
 };


### PR DESCRIPTION
Use `tty` instead of stdio streams to detect if stdio outputs are ttys to improve require speed.

`tty` is used by stdio streams, so if streams are initialized later or were initialized before there will be no overhead. However if streams are not used(`process.stdout` and `process.stderr` stream objects, not OS streams itself), it speeds up require times slightly.