### PR TITLE
Add Buildkite to the CI whitelist

### DIFF
--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ function supportsColor(haveStream, streamIsTTY) {
 	}
 
 	if ('CI' in env) {
-		if (['TRAVIS', 'CIRCLECI', 'APPVEYOR', 'GITLAB_CI', 'GITHUB_ACTIONS'].some(sign => sign in env) || env.CI_NAME === 'codeship') {
+		if (['TRAVIS', 'CIRCLECI', 'APPVEYOR', 'GITLAB_CI', 'GITHUB_ACTIONS', 'BUILDKITE'].some(sign => sign in env) || env.CI_NAME === 'codeship') {
 			return 1;
 		}
 

--- a/test.js
+++ b/test.js
@@ -191,6 +191,12 @@ test('return true if `GITLAB_CI` is in env', t => {
 	t.truthy(result.stdout);
 });
 
+test('return true if `BUILDKITE` is in env', t => {
+	process.env = {CI: true, BUILDKITE: true};
+	const result = importFresh('.');
+	t.truthy(result.stdout);
+});
+
 test('return true if Codeship is in env', t => {
 	process.env = {CI: true, CI_NAME: 'codeship'};
 	const result = importFresh('.');


### PR DESCRIPTION
This adds [Buildkite](https://buildkite.com/) to the whitelist of CI environments that support color output. Buildkite always has the [`CI`](https://buildkite.com/docs/pipelines/environment-variables#bk-env-vars-ci) and [`BUILDKITE`](https://buildkite.com/docs/pipelines/environment-variables#bk-env-vars-buildkite) environment variables set.