### PR TITLE
Add Drone CI to supported environments

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function supportsColor(haveStream, {streamIsTTY, sniffFlags = true} = {}) {
 	}
 
 	if ('CI' in env) {
-		if (['TRAVIS', 'CIRCLECI', 'APPVEYOR', 'GITLAB_CI', 'GITHUB_ACTIONS', 'BUILDKITE'].some(sign => sign in env) || env.CI_NAME === 'codeship') {
+		if (['TRAVIS', 'CIRCLECI', 'APPVEYOR', 'GITLAB_CI', 'GITHUB_ACTIONS', 'BUILDKITE', 'DRONE'].some(sign => sign in env) || env.CI_NAME === 'codeship') {
 			return 1;
 		}
 

--- a/test.js
+++ b/test.js
@@ -199,6 +199,12 @@ test('return true if `BUILDKITE` is in env', t => {
 	t.truthy(result.stdout);
 });
 
+test('return true if `DRONE` is in env', t => {
+	process.env = {CI: true, DRONE: true};
+	const result = importFresh('.');
+	t.truthy(result.stdout);
+});
+
 test('return true if Codeship is in env', t => {
 	process.env = {CI: true, CI_NAME: 'codeship'};
 	const result = importFresh('.');


### PR DESCRIPTION
[Drone CI](https://docs.drone.io/pipeline/environment/reference/drone/) supports displaying color on its web interface, so we can enable basic support for it.