### PR TITLE
Allow for hybrid CJS/ESM configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 yarn.lock
+index.cjs

--- a/babel.config.json
+++ b/babel.config.json
@@ -1,0 +1,3 @@
+{
+  "plugins": ["@babel/plugin-transform-modules-commonjs"]
+}

--- a/package.json
+++ b/package.json
@@ -11,15 +11,20 @@
 		"url": "https://sindresorhus.com"
 	},
 	"type": "module",
+	"main": "index.cjs",
+	"module": "index.js",
 	"exports": {
 		"node": "./index.js",
-		"default": "./browser.js"
+		"default": "./browser.js",
+		"require": "./index.cjs"
 	},
 	"engines": {
 		"node": ">=12"
 	},
 	"scripts": {
 		"//test": "xo && ava",
+		"build": "babel index.js --out-file index.cjs",
+		"postinstall": "npm run build",
 		"test": "xo"
 	},
 	"files": [
@@ -52,6 +57,9 @@
 		"has-flag": "^5.0.0"
 	},
 	"devDependencies": {
+		"@babel/cli": "^7.13.16",
+		"@babel/core": "^7.13.16",
+		"@babel/plugin-transform-modules-commonjs": "^7.13.8",
 		"ava": "^3.15.0",
 		"import-fresh": "^3.3.0",
 		"xo": "^0.38.2"


### PR DESCRIPTION
I don't particularly love having to add a "postinstall" script but it was the only way to do it without changing the process on how you publish the package to "npm".

Fixes #116 