### PR TITLE
Simplify the browser check

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,9 +1,8 @@
 /* eslint-env browser */
 
-// Check for Blink-based browsers.
-const isBlink = /\b(Chrome|Chromium)\//.test(navigator.userAgent);
+const isBlinkBasedBrowser = /\b(Chrome|Chromium)\//.test(navigator.userAgent);
 
-const colorSupport = isBlink ? {
+const colorSupport = isBlinkBasedBrowser ? {
 	level: 1,
 	hasBasic: true,
 	has256: false,

--- a/browser.js
+++ b/browser.js
@@ -1,10 +1,9 @@
 /* eslint-env browser */
 
-function getChromeVersion() {
-	return parseInt(String(navigator.userAgent).split(/\b(Chrome|Chromium)\//).pop());
-}
+// Check for Blink-based browsers.
+const isBlink = /\b(Chrome|Chromium)\//.test(navigator.userAgent);
 
-const colorSupport = getChromeVersion() >= 69 ? {
+const colorSupport = isBlink ? {
 	level: 1,
 	hasBasic: true,
 	has256: false,

--- a/browser.js
+++ b/browser.js
@@ -1,13 +1,7 @@
 /* eslint-env browser */
 
 function getChromeVersion() {
-	const matches = /(Chrome|Chromium)\/(?<chromeVersion>\d+)\./.exec(navigator.userAgent);
-
-	if (!matches) {
-		return;
-	}
-
-	return Number.parseInt(matches.groups.chromeVersion, 10);
+	return parseInt(String(navigator.userAgent).split(/\b(Chrome|Chromium)\//).pop());
 }
 
 const colorSupport = getChromeVersion() >= 69 ? {


### PR DESCRIPTION
Re: https://github.com/chalk/supports-color/pull/111#discussion_r638691436

Basically, that was checking for Chrome 69 or higher using a feature that is only available in Chrome 64 or higher, i.e. only covering a sub-optimal five-versions range, and causing it to break over any other non-ES2018 compliant browser.