### PR TITLE
Explicitly import `process`

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 import os from 'os';
 import tty from 'tty';
 import hasFlag from 'has-flag';
+import process from 'process';
 
 const {env} = process;
 


### PR DESCRIPTION
This explicitly imports process in this package. I was just experimenting getting this package to work in Deno, and it's nice to be able to support Node.js packages in Deno using just import maps without having to require eg the `process` global to be defined (since it's also kind of a security hole as well).

This behaviour is documented as recommended in https://nodejs.org/dist/latest-v16.x/docs/api/process.html#process_process as well.