### PR TITLE
Do we need the has-flag dependency?

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,12 @@
 import process from 'process'; // eslint-disable-line node/prefer-global/process
 import os from 'os';
 import tty from 'tty';
-import hasFlag from 'has-flag';
 
 const {env} = process;
+
+function hasFlag(flag) {
+	return process.argv.includes('--' + flag);
+}
 
 let flagForceColor;
 if (hasFlag('no-color') ||

--- a/package.json
+++ b/package.json
@@ -48,9 +48,7 @@
 		"truecolor",
 		"16m"
 	],
-	"dependencies": {
-		"has-flag": "^5.0.0"
-	},
+	"dependencies": {},
 	"devDependencies": {
 		"ava": "^3.15.0",
 		"import-fresh": "^3.3.0",


### PR DESCRIPTION
We might want the has-flag dependency if we want to keep any of the following extra features it provides over a simple `argv.includes` check:
- If we want to support single-dash, single-character flags like "-c" (looks like we don't)
- If we want to ignore flags that come after a "--": https://unix.stackexchange.com/questions/11376/what-does-double-dash-mean

Since these are undocumented behaviors of supports-color, can we safely assume that users are probably not (and should not be) relying on them?

If so, I think we could turn this into a zero-dependency library!