### PR TITLE
Support level 1 in Azure DevOps pipelines

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,6 +116,10 @@ function _supportsColor(haveStream, {streamIsTTY, sniffFlags = true} = {}) {
 		return /^(9\.(0*[1-9]\d*)\.|\d{2,}\.)/.test(env.TEAMCITY_VERSION) ? 1 : 0;
 	}
 
+	if ('TF_BUILD' in env && 'AGENT_NAME' in env) {
+		return 1;
+	}
+
 	if (env.COLORTERM === 'truecolor') {
 		return 3;
 	}

--- a/index.js
+++ b/index.js
@@ -116,6 +116,7 @@ function _supportsColor(haveStream, {streamIsTTY, sniffFlags = true} = {}) {
 		return /^(9\.(0*[1-9]\d*)\.|\d{2,}\.)/.test(env.TEAMCITY_VERSION) ? 1 : 0;
 	}
 
+	// Check for Azure DevOps pipelines
 	if ('TF_BUILD' in env && 'AGENT_NAME' in env) {
 		return 1;
 	}


### PR DESCRIPTION
Azure DevOps has supported displaying build/release logs with console colors (at least 16 - level 1) in their browser-based UI for  some time. 

I tested coloring our node CI build scripts using chalk, but found that I needed to _force color_ for things to work in the Azure DevOps build logs, even if the same scripts gave colored output on my local machine.

After reviewing the `supports-color` package, I realized that you are doing environment variable tests to detect different CI provider environments like Team City, Github Actions, Travis,  AppVeyor etc, but no test for Azure DevOps.

I have therefore added a test that should verify that the script is running in Azure DevOps.
I have tested this in Azure DevOps, and the variables will work in both Build and Release Pipelines.

Reference: https://docs.microsoft.com/en-us/azure/devops/pipelines/build/variables?view=azure-devops&tabs=yaml
(Note that the actual environment variables in this list has "." replaced with "_" and they are all uppercase.)

I hope you can accept my PR, and hopefully also release new verisons of `supports-color` and `chalk`