### PR TITLE
Make hybrid commonjs/esm package

### DIFF
--- a/cjs/index.js
+++ b/cjs/index.js
@@ -1,8 +1,10 @@
-import process from 'node:process';
-import os from 'node:os';
-import tty from 'node:tty';
+/* eslint-disable unicorn/prefer-module */
 
-// End ESM imports
+const process = require('process');
+const os = require('os');
+const tty = require('tty');
+
+// End CommonJS imports
 
 // From: https://github.com/sindresorhus/has-flag/blob/main/index.js
 function hasFlag(flag, argv = process.argv) {
@@ -163,11 +165,10 @@ function createSupportsColorInternal(stream, options = {}) {
 	return translateLevel(level);
 }
 
-// Start ESM exports
+// Start CommonJS exports
 
-export const createSupportsColor = createSupportsColorInternal;
-
-export default {
+module.exports = {
+	createSupportsColor: createSupportsColorInternal,
 	stdout: createSupportsColorInternal({isTTY: tty.isatty(1)}),
 	stderr: createSupportsColorInternal({isTTY: tty.isatty(2)}),
 };

--- a/cjs/package.json
+++ b/cjs/package.json
@@ -1,0 +1,3 @@
+{
+	"type": "commonjs"
+}

--- a/index.js
+++ b/index.js
@@ -167,7 +167,9 @@ function createSupportsColorInternal(stream, options = {}) {
 
 export const createSupportsColor = createSupportsColorInternal;
 
-export default {
+const defaultExport = {
 	stdout: createSupportsColorInternal({isTTY: tty.isatty(1)}),
 	stderr: createSupportsColorInternal({isTTY: tty.isatty(2)}),
 };
+
+export default defaultExport;

--- a/package.json
+++ b/package.json
@@ -11,10 +11,16 @@
 		"url": "https://sindresorhus.com"
 	},
 	"type": "module",
+	"main": "./cjs/index.js",
+	"module": "./index.js",
 	"exports": {
-		"node": "./index.js",
+		"node": {
+			"require": "./cjs/index.js",
+			"import": "./index.js"
+		},
 		"default": "./browser.js"
 	},
+	"types": "./index.d.ts",
 	"engines": {
 		"node": ">=12"
 	},
@@ -26,7 +32,8 @@
 		"index.js",
 		"index.d.ts",
 		"browser.js",
-		"browser.d.ts"
+		"browser.d.ts",
+		"cjs/**/*"
 	],
 	"keywords": [
 		"color",


### PR DESCRIPTION
I recently created [PR #126](https://github.com/chalk/supports-color/pull/126) for Azure DevOps support.
I was actually not aware that the next releases of `chalk` and `supports-color` with my PR changes included would be ESM-module-only packages.

I cannot yet use ESM packages with my scripts that use chalk, therefore the latest release that included my own PR does not solve my own problems 🙄. I'm planning to move my own codebase to ESM quite soon, but still need to wait for better support in Jest.

With __chalk's__ high number of dependents and weekly downloads, I really think `chalk` as well as `supports-color` and `ansi-styles` deserve to become hybrid CommonJS/ESM module packages while the node ecosystem slowly (but surely?) transitions from CommonJS to ESM. Packages supporting both ESM and CommonJS means they can be used from projects with either module standard in this transition phase of unknown duration. This would also resolve my personal need BTW 🙂.

In this pull request I did the following to make the package "hybrid" (have both ESM/CommonJS support ) :

* I made some minor modifications to `index.js` to ensure all ESM import statements are in the first lines of the file, and all the ESM exports on the last lines.
* I added `cjs/index.js`, and changed the imports and exports from the ESM file to CommonJS syntax. Every line between imports and exports are identical in both files.
* Added an additional package.json in the cjs folder to specify the folder level module type.
* Added more conditional exports to package.json to make the package a hybrid ESM/CommonJS package.

Reference: [2ality.com: Hybrid npm packages (ESM and CommonJS), Option 2](https://2ality.com/2019/10/hybrid-npm-packages.html#option-2%3A-bare-import-commonjs%2C-deep-import-esm-(maximum-backward-compatibility))

> Remark: It would obviously be better to not have to maintain both the ESM index.js file and the CommonJS index.js file even if only the imports and exports at the top/bottom differ . Personally, I would typically write the source code in TypeScript and then compile to different module formats. Not sure how you would prefer this to be done here. 

If it sounds interesting to make `chalk`,  `supports-color` and `ansi-styles` into hybrid module format packages, let me know. I could help out doing this for the two other packages as well. 