### PR TITLE
Move test for Azure DevOps environment up

### DIFF
--- a/index.js
+++ b/index.js
@@ -80,6 +80,11 @@ function _supportsColor(haveStream, {streamIsTTY, sniffFlags = true} = {}) {
 		}
 	}
 
+	// Check for Azure DevOps pipelines
+	if ('TF_BUILD' in env && 'AGENT_NAME' in env) {
+		return 1;
+	}
+
 	if (haveStream && !streamIsTTY && forceColor === undefined) {
 		return 0;
 	}
@@ -114,11 +119,6 @@ function _supportsColor(haveStream, {streamIsTTY, sniffFlags = true} = {}) {
 
 	if ('TEAMCITY_VERSION' in env) {
 		return /^(9\.(0*[1-9]\d*)\.|\d{2,}\.)/.test(env.TEAMCITY_VERSION) ? 1 : 0;
-	}
-
-	// Check for Azure DevOps pipelines
-	if ('TF_BUILD' in env && 'AGENT_NAME' in env) {
-		return 1;
 	}
 
 	if (env.COLORTERM === 'truecolor') {


### PR DESCRIPTION
I recently contributed with PR #126 to support color (level 1) in Azure DevOps pipelines.

I have now tried it out in an Azure DevOps pipeline, but unfortunately ___it did not work___.
I then found that new condition in the code from my PR was added to late in the function; a preceding condition terminates the function/returns before hitting my code.

I have done some better testing now, and moved my Azure check higher up, right before the condition that terminated the function. With this change I have verified that it works in Azure DevOps.
Sorry for not testing better in the first PR, I assumed that my check would work close to the other CI Platform checks. 

I hope you can accept this update, hopefully followed up by a new release of `chalk`. 

_And BTW: Related to the ESM only vs. hybrid package strategy topic from my previous PR: I actually salute you for your ESM only strategy to force the node ecosystem towards ESM. Your strategy worked on me, I spent close to one week updating my company's 30+ internal npm packages to ESM only packages._