### PR TITLE
Check the presence of `NO_COLOR` environment variable to disable color

### DIFF
--- a/index.js
+++ b/index.js
@@ -86,7 +86,7 @@ function _supportsColor(haveStream, {streamIsTTY, sniffFlags = true} = {}) {
 
 	const min = forceColor || 0;
 
-	if (env.TERM === 'dumb') {
+	if (env.TERM === 'dumb' || 'NO_COLOR' in env) {
 		return min;
 	}
 


### PR DESCRIPTION
Closes #129 