### PR TITLE
Fix split errors on windows github actions

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,19 @@
+name: Node CI
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test-ubuntu:
+    uses: ./.github/workflows/test.yml
+    with:
+      os: ubuntu-latest
+  test-macos:
+    uses: ./.github/workflows/test.yml
+    with:
+      os: macos-latest
+  test-windows:
+    uses: ./.github/workflows/test.yml
+    with:
+      os: windows-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,15 +1,21 @@
 name: CI
+
 on:
-  - push
-  - pull_request
+  workflow_call:
+    inputs:
+      os:
+        required: true
+        type: string
+
 jobs:
   test:
-    name: Node.js ${{ matrix.node-version }}
-    runs-on: ubuntu-latest
+    name: Node.js ${{ matrix.node-version }} on ${{ inputs.os }}
+    runs-on: ${{ inputs.os }}
     strategy:
       fail-fast: false
       matrix:
         node-version:
+          - 18
           - 16
           - 14
           - 12

--- a/index.js
+++ b/index.js
@@ -91,14 +91,19 @@ function _supportsColor(haveStream, {streamIsTTY, sniffFlags = true} = {}) {
 	}
 
 	if (process.platform === 'win32') {
-		// Windows 10 build 10586 is the first Windows release that supports 256 colors.
-		// Windows 10 build 14931 is the first release that supports 16m/TrueColor.
-		const osRelease = os.release().split('.');
-		if (
-			Number(osRelease[0]) >= 10
-			&& Number(osRelease[2]) >= 10_586
-		) {
-			return Number(osRelease[2]) >= 14_931 ? 3 : 2;
+		// Optional chaining support didn't drop until Node 14 so using the long-form.
+		const osRelease = os.release();
+
+		if (osRelease) {
+			// Windows 10 build 10586 is the first Windows release that supports 256 colors.
+			// Windows 10 build 14931 is the first release that supports 16m/TrueColor.
+			const splitOsRelease = osRelease.split('.');
+			if (
+				Number(splitOsRelease[0]) >= 10
+				&& Number(splitOsRelease[2]) >= 10_586
+			) {
+				return Number(splitOsRelease[2]) >= 14_931 ? 3 : 2;
+			}
 		}
 
 		return 1;

--- a/index.js
+++ b/index.js
@@ -56,6 +56,25 @@ function translateLevel(level) {
 	};
 }
 
+function getWin32Support() {
+	// Optional chaining support didn't drop until Node 14 so using the long-form.
+	const osRelease = os.release();
+
+	if (osRelease) {
+		// Windows 10 build 10586 is the first Windows release that supports 256 colors.
+		// Windows 10 build 14931 is the first release that supports 16m/TrueColor.
+		const splitOsRelease = osRelease.split('.');
+		if (
+			Number(splitOsRelease[0]) >= 10
+			&& Number(splitOsRelease[2]) >= 10_586
+		) {
+			return Number(splitOsRelease[2]) >= 14_931 ? 3 : 2;
+		}
+	}
+
+	return 1;
+}
+
 function _supportsColor(haveStream, {streamIsTTY, sniffFlags = true} = {}) {
 	const noFlagForceColor = envForceColor();
 	if (noFlagForceColor !== undefined) {
@@ -91,22 +110,7 @@ function _supportsColor(haveStream, {streamIsTTY, sniffFlags = true} = {}) {
 	}
 
 	if (process.platform === 'win32') {
-		// Optional chaining support didn't drop until Node 14 so using the long-form.
-		const osRelease = os.release();
-
-		if (osRelease) {
-			// Windows 10 build 10586 is the first Windows release that supports 256 colors.
-			// Windows 10 build 14931 is the first release that supports 16m/TrueColor.
-			const splitOsRelease = osRelease.split('.');
-			if (
-				Number(splitOsRelease[0]) >= 10
-				&& Number(splitOsRelease[2]) >= 10_586
-			) {
-				return Number(splitOsRelease[2]) >= 14_931 ? 3 : 2;
-			}
-		}
-
-		return 1;
+		return getWin32Support();
 	}
 
 	if ('CI' in env) {

--- a/test.js
+++ b/test.js
@@ -317,6 +317,18 @@ test('return level 3 if on Windows 10 build 14931 or later', t => {
 	t.is(result.stdout.level, 3);
 });
 
+test('return level 1 if os release is undefined', t => {
+	Object.defineProperty(process, 'platform', {
+		value: 'win32',
+	});
+	Object.defineProperty(process.versions, 'node', {
+		value: '8.0.0',
+	});
+	os.release = () => undefined;
+	const result = importFresh('./index.js');
+	t.is(result.stdout.level, 1);
+});
+
 test('return level 2 when FORCE_COLOR is set when not TTY in xterm256', t => {
 	process.stdout.isTTY = false;
 	process.env.FORCE_COLOR = true;


### PR DESCRIPTION
```
Error: TypeError: Cannot read properties of undefined (reading 'split')

    at supportsColor (node_modules/supports-color/index.js:85:33)
```
https://github.com/facebook/jest/runs/7504665026?check_suite_focus=true