### PR TITLE
Fix TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -45,7 +45,7 @@ export interface ColorSupport {
 
 export type ColorInfo = ColorSupport | false;
 
-export function createSupportsColor(stream: WriteStream, options?: Options): ColorInfo;
+export function createSupportsColor(stream?: WriteStream, options?: Options): ColorInfo;
 
 declare const supportsColor: {
 	stdout: ColorInfo;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -9,5 +9,6 @@ expectType<ColorInfo>(supportsColor.stderr);
 
 expectType<ColorInfo>(createSupportsColor(stdout));
 expectType<ColorInfo>(createSupportsColor(stderr));
+expectType<ColorInfo>(createSupportsColor(undefined));
 
 expectType<ColorInfo>(createSupportsColor(stdout, options));


### PR DESCRIPTION
We have logic to check the `haveStream` if a falsy value. So we should mark `stream` as optional.