### PR TITLE
feat: support for CommonJS

### DIFF
--- a/index.cjs
+++ b/index.cjs
@@ -1,0 +1,171 @@
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+  for (var name in all)
+    __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// index.js
+var supports_color_exports = {};
+__export(supports_color_exports, {
+  createSupportsColor: () => createSupportsColor,
+  default: () => supports_color_default
+});
+module.exports = __toCommonJS(supports_color_exports);
+var import_node_process = __toESM(require("node:process"), 1);
+var import_node_os = __toESM(require("node:os"), 1);
+var import_node_tty = __toESM(require("node:tty"), 1);
+function hasFlag(flag, argv = globalThis.Deno ? globalThis.Deno.args : import_node_process.default.argv) {
+  const prefix = flag.startsWith("-") ? "" : flag.length === 1 ? "-" : "--";
+  const position = argv.indexOf(prefix + flag);
+  const terminatorPosition = argv.indexOf("--");
+  return position !== -1 && (terminatorPosition === -1 || position < terminatorPosition);
+}
+var { env } = import_node_process.default;
+var flagForceColor;
+if (hasFlag("no-color") || hasFlag("no-colors") || hasFlag("color=false") || hasFlag("color=never")) {
+  flagForceColor = 0;
+} else if (hasFlag("color") || hasFlag("colors") || hasFlag("color=true") || hasFlag("color=always")) {
+  flagForceColor = 1;
+}
+function envForceColor() {
+  if (!("FORCE_COLOR" in env)) {
+    return;
+  }
+  if (env.FORCE_COLOR === "true") {
+    return 1;
+  }
+  if (env.FORCE_COLOR === "false") {
+    return 0;
+  }
+  if (env.FORCE_COLOR.length === 0) {
+    return 1;
+  }
+  const level = Math.min(Number.parseInt(env.FORCE_COLOR, 10), 3);
+  if (![0, 1, 2, 3].includes(level)) {
+    return;
+  }
+  return level;
+}
+function translateLevel(level) {
+  if (level === 0) {
+    return false;
+  }
+  return {
+    level,
+    hasBasic: true,
+    has256: level >= 2,
+    has16m: level >= 3
+  };
+}
+function _supportsColor(haveStream, { streamIsTTY, sniffFlags = true } = {}) {
+  const noFlagForceColor = envForceColor();
+  if (noFlagForceColor !== void 0) {
+    flagForceColor = noFlagForceColor;
+  }
+  const forceColor = sniffFlags ? flagForceColor : noFlagForceColor;
+  if (forceColor !== void 0) {
+    return forceColor;
+  }
+  if (sniffFlags) {
+    if (hasFlag("color=16m") || hasFlag("color=full") || hasFlag("color=truecolor")) {
+      return 3;
+    }
+    if (hasFlag("color=256")) {
+      return 2;
+    }
+  }
+  if ("TF_BUILD" in env && "AGENT_NAME" in env) {
+    return 1;
+  }
+  if (haveStream && !streamIsTTY && forceColor === void 0) {
+    return 0;
+  }
+  const min = 0;
+  if (env.TERM === "dumb") {
+    return min;
+  }
+  if (import_node_process.default.platform === "win32") {
+    const osRelease = import_node_os.default.release().split(".");
+    if (Number(osRelease[0]) >= 10 && Number(osRelease[2]) >= 10586) {
+      return Number(osRelease[2]) >= 14931 ? 3 : 2;
+    }
+    return 1;
+  }
+  if ("CI" in env) {
+    if ("GITHUB_ACTIONS" in env || "GITEA_ACTIONS" in env) {
+      return 3;
+    }
+    if (["TRAVIS", "CIRCLECI", "APPVEYOR", "GITLAB_CI", "BUILDKITE", "DRONE"].some((sign) => sign in env) || env.CI_NAME === "codeship") {
+      return 1;
+    }
+    return min;
+  }
+  if ("TEAMCITY_VERSION" in env) {
+    return /^(9\.(0*[1-9]\d*)\.|\d{2,}\.)/.test(env.TEAMCITY_VERSION) ? 1 : 0;
+  }
+  if (env.COLORTERM === "truecolor") {
+    return 3;
+  }
+  if (env.TERM === "xterm-kitty") {
+    return 3;
+  }
+  if ("TERM_PROGRAM" in env) {
+    const version = Number.parseInt((env.TERM_PROGRAM_VERSION || "").split(".")[0], 10);
+    switch (env.TERM_PROGRAM) {
+      case "iTerm.app": {
+        return version >= 3 ? 3 : 2;
+      }
+      case "Apple_Terminal": {
+        return 2;
+      }
+    }
+  }
+  if (/-256(color)?$/i.test(env.TERM)) {
+    return 2;
+  }
+  if (/^screen|^xterm|^vt100|^vt220|^rxvt|color|ansi|cygwin|linux/i.test(env.TERM)) {
+    return 1;
+  }
+  if ("COLORTERM" in env) {
+    return 1;
+  }
+  return min;
+}
+function createSupportsColor(stream, options = {}) {
+  const level = _supportsColor(stream, {
+    streamIsTTY: stream && stream.isTTY,
+    ...options
+  });
+  return translateLevel(level);
+}
+var supportsColor = {
+  stdout: createSupportsColor({ isTTY: import_node_tty.default.isatty(1) }),
+  stderr: createSupportsColor({ isTTY: import_node_tty.default.isatty(2) })
+};
+var supports_color_default = supportsColor;
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+  createSupportsColor
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
 	"type": "module",
 	"exports": {
 		"types": "./index.d.ts",
-		"node": "./index.js",
+		"require": "./index.cjs",
+    "import": "./index.js",
 		"default": "./browser.js"
 	},
 	"sideEffects": false,
@@ -21,7 +22,8 @@
 		"node": ">=18"
 	},
 	"scripts": {
-		"test": "xo && ava && tsd"
+		"test": "xo && ava && tsd",
+		"build:cjs": "esbuild index.js --bundle --platform=node --format=cjs --target=node18 --outfile=index.cjs"
 	},
 	"files": [
 		"index.js",
@@ -54,6 +56,7 @@
 	"devDependencies": {
 		"@types/node": "^20.11.17",
 		"ava": "^6.1.1",
+		"esbuild": "^0.24.0",
 		"tsd": "^0.30.4",
 		"xo": "^0.57.0"
 	},

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
 	},
 	"files": [
 		"index.js",
+		"index.cjs",
 		"index.d.ts",
 		"browser.js",
 		"browser.d.ts"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
 		"node": ">=18"
 	},
 	"scripts": {
-		"test": "xo && ava && tsd",
+		"test": "xo --ignore=index.cjs && ava && tsd",
 		"build:cjs": "esbuild index.js --bundle --platform=node --format=cjs --target=node18 --outfile=index.cjs"
 	},
 	"files": [

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 	"exports": {
 		"types": "./index.d.ts",
 		"require": "./index.cjs",
-    "import": "./index.js",
+    "node": "./index.js",
 		"default": "./browser.js"
 	},
 	"sideEffects": false,


### PR DESCRIPTION
Hi, **team** 🙌

I would like to propose a compilation of _index.js_ to make the project compatible with `CommonJS`, without changing the code or the supported versions (e.g, **Node.js** `v18`).

### Why?

From **Node.js** `v23`, an experimental feature _(`support for loading ES Module in require()`)_ has been added, which brings up the following error for any command executed from **npm**:

```
(node:16132) ExperimentalWarning: CommonJS module <***>/lib/node_modules/npm/node_modules/debug/src/node.js is loading ES Module <***>/lib/node_modules/npm/node_modules/supports-color/index.js using require().
Support for loading ES Module in require() is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
```

- This warning comes up with a simple `npm ls`, `npm i` or `npm view npm version`, for example.

---

### The changes

The real changes were made to the _package.json_, where the new _index.cjs_ file was automatically generated by the `npm run build:cjs` script _(I used **esbuild** because it's dependency-free — it could be any compiler)_.

From a certain point of view, this _PR_ could also be considered as a fix rather than a feature:

- `fix: support for Node.js v23 without experimental resources`

> [!IMPORTANT]
> As there is no workflow that automates publishing, it's important to note that the compilation of index.cjs is done manually.
>
> If we create a workflow to automate the publication, the _index.cjs_ would become dispensable from the commit and could be compiled during the _CI_ (which is my personal preference).

> [!NOTE]
> I noticed that 4 tests were failing, but I didn't touch them or the main file _(index.js)_.
> It would be a pleasure to help with the correction of these tests if necessary.

---

### Related

> Some _key_ issues, comments and _PRs_.

- Who depends on `support-color` using `require()`:
  - https://github.com/debug-js/debug/issues/975
- When the warning was introduced:
  - https://github.com/nodejs/node/pull/55397
- When the warning was issued:
  - https://github.com/nodejs/node/pull/55338#issuecomment-2411753894
- A closed _PR_ trying to fix this from **npm (CLI)** side:
  - https://github.com/npm/cli/pull/7887#issuecomment-2450500742

---

### CC

@sindresorhus, @Qix-, @ljharb, @mantoni _(and all the community)_, it would be great if we could discuss this or, perhaps, an alternative approach 🤝
