### PR TITLE
WezTerm supports truecolor

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,6 +151,10 @@ function _supportsColor(haveStream, {streamIsTTY, sniffFlags = true} = {}) {
 		return 3;
 	}
 
+	if (env.TERM === 'wezterm') {
+		return 3;
+	}
+
 	if ('TERM_PROGRAM' in env) {
 		const version = Number.parseInt((env.TERM_PROGRAM_VERSION || '').split('.')[0], 10);
 


### PR DESCRIPTION
Add detection of WezColor and report 16m color support. It exports COLORTERM as truecolor, but that doesn't propagate across ssh sessions, so this will help with proper color detection in all environments.